### PR TITLE
BAU: Removes 'recreate' deployments to avoid downtime

### DIFF
--- a/copilot/fsd-pre-award-stores/manifest.yml
+++ b/copilot/fsd-pre-award-stores/manifest.yml
@@ -70,8 +70,6 @@ environments:
     count:
       spot: 1
   test:
-    deployment:
-      rolling: "recreate"
     count:
       spot: 2
   uat:


### PR DESCRIPTION
### Change description
To bring this in line with all other services, removes recreate deployments from the test environment to avoid downtime errors.
