### PR TITLE
adding prospectus link to data for notify

### DIFF
--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -197,7 +197,7 @@ class ApplicationsView(MethodView):
                 **application_with_form_json,
                 "fund_name": fund_name,
                 "round_name": round_name,
-                "prospectus_url": round_data.prospectus_link,
+                "prospectus_url": round_data.prospectus_url,
             }
 
             self._send_submit_queue(application_id, application_with_form_json)

--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -197,6 +197,7 @@ class ApplicationsView(MethodView):
                 **application_with_form_json,
                 "fund_name": fund_name,
                 "round_name": round_name,
+                "prospectus_url": round_data.prospectus_link,
             }
 
             self._send_submit_queue(application_id, application_with_form_json)

--- a/application_store/external_services/models/round.py
+++ b/application_store/external_services/models/round.py
@@ -31,7 +31,7 @@ class Round:
     short_name: str
     contact_email: str
     title_json: str
-    prospectus_link: str
+    prospectus_url: str
     project_name_field_id: Optional[str] = None
     mark_as_complete_enabled: bool = False
     is_expression_of_interest: bool = False
@@ -59,5 +59,5 @@ class Round:
             mark_as_complete_enabled=data.get("mark_as_complete_enabled") or False,
             is_expression_of_interest=data.get("is_expression_of_interest") or False,
             title_json=data["title_json"],
-            prospectus_link=data["prospectus"],
+            prospectus_url=data["prospectus"],
         )

--- a/application_store/external_services/models/round.py
+++ b/application_store/external_services/models/round.py
@@ -31,6 +31,7 @@ class Round:
     short_name: str
     contact_email: str
     title_json: str
+    prospectus_link: str
     project_name_field_id: Optional[str] = None
     mark_as_complete_enabled: bool = False
     is_expression_of_interest: bool = False
@@ -58,4 +59,5 @@ class Round:
             mark_as_complete_enabled=data.get("mark_as_complete_enabled") or False,
             is_expression_of_interest=data.get("is_expression_of_interest") or False,
             title_json=data["title_json"],
+            prospectus_link=data["prospectus"],
         )

--- a/tests/application_store_tests/api_data/get_endpoint_data.json
+++ b/tests/application_store_tests/api_data/get_endpoint_data.json
@@ -82,6 +82,7 @@
       "opens": "2022-02-01T00:00:01",
       "deadline": "2022-06-01T00:00:00",
       "assessment_deadline": "2022-09-30T00:00:00",
+      "prospectus": "http://test.com",
       "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -115,6 +116,7 @@
       "opens": "2022-02-01T00:00:01",
       "deadline": "2022-06-01T00:00:00",
       "assessment_deadline": "2022-09-30T00:00:00",
+      "prospectus": "http://test.com",
       "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -148,6 +150,7 @@
       "opens": "2022-02-01T00:00:01",
       "deadline": "2022-06-01T00:00:00",
       "assessment_deadline": "2022-09-30T00:00:00",
+      "prospectus": "http://test.com",
       "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -179,6 +182,7 @@
       "opens": "2022-06-01T00:00:01",
       "deadline": "2022-08-31T00:00:00",
       "assessment_deadline": "2022-12-30T00:00:00",
+      "prospectus": "http://test.com",
       "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -210,6 +214,7 @@
       "opens": "2022-09-01T00:00:01",
       "deadline": "2022-11-30T00:00:00",
       "assessment_deadline": "2023-03-30T00:00:00",
+      "prospectus": "http://test.com",
       "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -243,6 +248,7 @@
     "deadline": "2022-06-01T00:00:00",
     "assessment_deadline": "2022-09-30T00:00:00",
     "title_json": {"en": "English fund name", "cy": "Welsh fund name"},
+    "prospectus": "http://test.com",
     "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -276,6 +282,7 @@
     "deadline": "2022-06-01T00:00:00",
     "round_name": "random_round_name",
     "assessment_deadline": "2022-09-30T00:00:00",
+    "prospectus": "http://test.com",
     "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -307,6 +314,7 @@
     "opens": "2022-02-01T00:00:01",
     "deadline": "2022-06-01T00:00:00",
     "round_name": "random_round_name",
+    "prospectus": "http://test.com",
     "assessment_deadline": "2022-09-30T00:00:00",
     "assessment_criteria_weighting": [
             {
@@ -338,6 +346,7 @@
     "id": "c603d114-5364-4474-a0c4-c41cbf4d3bbd",
     "opens": "2022-06-01T00:00:01",
     "deadline": "2022-08-31T00:00:00",
+    "prospectus": "http://test.com",
     "assessment_deadline": "2022-09-30T00:00:00",
     "assessment_criteria_weighting": [
             {
@@ -371,6 +380,7 @@
     "deadline": "2022-11-30T00:00:00",
     "round_name": "random_round_name",
     "assessment_deadline": "2022-09-30T00:00:00",
+    "prospectus": "http://test.com",
     "assessment_criteria_weighting": [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",

--- a/tests/application_store_tests/conftest.py
+++ b/tests/application_store_tests/conftest.py
@@ -271,6 +271,7 @@ def generate_mock_round(fund_id: str, round_id: str) -> Round:
         project_name_field_id="TestFieldId",
         contact_email="test@outlook.com",
         title_json={"en": "English title", "cy": "Welsh title"},
+        prospectus_url="http://test.com",
     )
 
 

--- a/tests/application_store_tests/test_routes.py
+++ b/tests/application_store_tests/test_routes.py
@@ -773,6 +773,7 @@ def generate_mock_round_closed(fund_id: str, round_id: str) -> Round:
         project_name_field_id="TestFieldId",
         contact_email="test@outlook.com",
         title_json={"en": "English title", "cy": "Welsh title"},
+        prospectus_url="http://test.com",
     )
 
 


### PR DESCRIPTION
### Change description
[An earlier PR](https://github.com/communitiesuk/funding-service-design-notification/pull/296) on `notification` adds an additional field to the application record or submission template (prospectus URL). This PR adds that field into the data sent to the queue for notification

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

