### PR TITLE
Increase CPU for pre-award-stores

### DIFF
--- a/copilot/fsd-pre-award-stores/manifest.yml
+++ b/copilot/fsd-pre-award-stores/manifest.yml
@@ -25,7 +25,7 @@ image:
   # Port exposed through your container to route traffic to it.
   port: 8080
 
-cpu: 512 # Number of CPU units for the task.
+cpu: 1024 # Number of CPU units for the task.
 memory: 1024 # Amount of memory in MiB used by the task.
 platform: linux/x86_64 # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
 count: 1 # Number of tasks that should be running in your service.


### PR DESCRIPTION
This app will be doing the work of three stores soon, and giving it 0.5 CPU is leading to significant throttling/delays when processing even a small amount of concurrent users (e2e tests) in our lower environments.

Let's give it a (barely) more respectable resource allocation.

This will be something to continue to monitor/tweak as we bring in more apps, eg frontends.