### PR TITLE
Set a valid CPU+Memory combination

### DIFF
--- a/copilot/fsd-pre-award-stores/manifest.yml
+++ b/copilot/fsd-pre-award-stores/manifest.yml
@@ -26,7 +26,7 @@ image:
   port: 8080
 
 cpu: 1024 # Number of CPU units for the task.
-memory: 1024 # Amount of memory in MiB used by the task.
+memory: 2048 # Amount of memory in MiB used by the task.
 platform: linux/x86_64 # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
 count: 1 # Number of tasks that should be running in your service.
 exec: true # Enable running commands in your container.


### PR DESCRIPTION
ECS doesn't allow 1024 CPU with 1024 memory. If you want 1024 CPU, the minimum memory allowed is 2048. So let's bump up to that.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html