### PR TITLE
Check DB migrations in CI

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -40,6 +40,7 @@ jobs:
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
     with:
       postgres_unit_testing: true
+      check_db_migrations: true
 
   paketo_build:
     needs: [ setup ]


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-153

### Change description
Pre-award-stores uses Alembic to manage DB migrations, helping to update the structure of our DB tables when the related Python models change.

In some of the non-consolidated pre-award-stores, we saw that the structure of the DB was not actually in sync with the Python models because some migration steps were missed.

This CI check will fail if there are any pending alembic migrations that need generating.
