### PR TITLE
Pull image location from paketo build step

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -61,9 +61,8 @@ jobs:
     with:
       environment: dev
       app_name: pre-award-stores
-      version: sha-${{ github.sha }}
-      image_location: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
       db_name: pre_award_stores
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_dev_deploy_tests:
     needs: dev_deploy
@@ -93,9 +92,8 @@ jobs:
     with:
       environment: test
       app_name: pre-award-stores
-      version: sha-${{ github.sha }}
-      image_location: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
       db_name: pre_award_stores
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_test_deploy_tests:
     needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, paketo_build, setup ]
@@ -126,9 +124,8 @@ jobs:
     with:
       environment: uat
       app_name: pre-award-stores
-      version: sha-${{ github.sha }}
-      image_location: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
       db_name: pre_award_stores
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_uat_deploy_tests:
     needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, post_test_deploy_tests, uat_deploy, paketo_build, setup ]
@@ -159,6 +156,5 @@ jobs:
     with:
       environment: prod
       app_name: pre-award-stores
-      version: sha-${{ github.sha }}
-      image_location: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
       db_name: pre_award_stores
+      image_location: ${{ needs.paketo_build.outputs.image_location }}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-154

https://github.com/communitiesuk/funding-service-design-workflows/pull/215
started to output the paketo image URI, so we can now reuse that rather
than passing fragments into the deploy steps which are used to rebuild
the image URI manually. This will reduce problems with the image URI
potentially going out of sync, and allow it to be used for eg database
migrations.