### PR TITLE
FSPT-123: Trace all requests on pre-prod

### DIFF
--- a/copilot/fsd-pre-award-stores/manifest.yml
+++ b/copilot/fsd-pre-award-stores/manifest.yml
@@ -58,6 +58,7 @@ variables:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-NotificationDeadLetterQueueURL
   ACCOUNT_STORE_API_HOST: http://fsd-account-store:8080
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
+  SENTRY_TRACES_SAMPLE_RATE: 1.0
 
 secrets:
   FUND_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FUND_STORE_API_HOST
@@ -101,3 +102,4 @@ environments:
     variables:
       FLASK_ENV: production
       ASSESSMENT_FRONTEND_HOST: "https://assessment.access-funding.levellingup.gov.uk"
+      SENTRY_TRACES_SAMPLE_RATE: 0.02


### PR DESCRIPTION
### Change description
Override to trace all requests on pre-prod

The production value is based on utils default from: https://github.com/communitiesuk/funding-service-design-utils/blob/b65c285328847640f8622c368595938b60e44d02/fsd_utils/sentry/init_sentry.py#L19C59-L19C63 we could possibly increase this in future, but previously a combination of bot traffic and looping errors have used all our quota.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
More requests should be being traced post-deployment


### Screenshots of UI changes (if applicable)
