### PR TITLE
updating script to check is ggis available otherwise add none

### DIFF
--- a/fund_store/db/queries.py
+++ b/fund_store/db/queries.py
@@ -277,7 +277,7 @@ def insert_fund_data(fund_config, commit: bool = True):
         "owner_organisation_name": fund_config["owner_organisation_name"],
         "owner_organisation_shortname": fund_config["owner_organisation_shortname"],
         "owner_organisation_logo_uri": fund_config["owner_organisation_logo_uri"],
-        "ggis_scheme_reference_number": fund_config["ggis_scheme_reference_number"],
+        "ggis_scheme_reference_number": fund_config["ggis_scheme_reference_number"] if 'ggis_scheme_reference_number' in fund_config else None,
         "funding_type": fund_config["funding_type"],
     }
 

--- a/fund_store/db/queries.py
+++ b/fund_store/db/queries.py
@@ -277,7 +277,7 @@ def insert_fund_data(fund_config, commit: bool = True):
         "owner_organisation_name": fund_config["owner_organisation_name"],
         "owner_organisation_shortname": fund_config["owner_organisation_shortname"],
         "owner_organisation_logo_uri": fund_config["owner_organisation_logo_uri"],
-        "ggis_scheme_reference_number": fund_config["ggis_scheme_reference_number"] if 'ggis_scheme_reference_number' in fund_config else None,
+        "ggis_scheme_reference_number": fund_config.get("ggis_scheme_reference_number"),
         "funding_type": fund_config["funding_type"],
     }
 


### PR DESCRIPTION
### Change description
This is a hot fix done for the GGIS field which is going to use in future with cabinet office integration (No specific timeframe for this integration) and this field is a non mandatory field so if fund has data it will be saved on the DB and if not it will be a null field. (I think this field came with the data standard changes.)

No unit test needed because there are some unit testes that covering up this field

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
01. Run the fund config all load script


### Screenshots of UI changes (if applicable)
![image](https://github.com/user-attachments/assets/ee58be63-59c3-43bc-ba1d-527426c1955d)

