### PR TITLE
Fspt 177 apply submit to assess

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,4 @@
 {
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
     "editor.quickSuggestions": {
         "other": true,
         "comments": false,
@@ -16,5 +11,10 @@
       },
       "editor.formatOnSave": true,
       "editor.defaultFormatter": "charliermarsh.ruff"
-    }
+    },
+    "python.testing.pytestArgs": [
+      "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
     "editor.quickSuggestions": {
         "other": true,
         "comments": false,
@@ -11,10 +16,5 @@
       },
       "editor.formatOnSave": true,
       "editor.defaultFormatter": "charliermarsh.ruff"
-    },
-    "python.testing.pytestArgs": [
-      "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    }
 }

--- a/application_store/_helpers/application.py
+++ b/application_store/_helpers/application.py
@@ -74,6 +74,7 @@ def send_submit_notification(
                     "Unknown eoi_decision [{eoi_decision}], unable to send submit notification",
                     extra=dict(eoi_decision=eoi_decision),
                 )
+                return
     else:
         notify_template = Config.NOTIFY_TEMPLATE_SUBMIT_APPLICATION
 

--- a/application_store/_helpers/application.py
+++ b/application_store/_helpers/application.py
@@ -69,6 +69,11 @@ def send_submit_notification(
             case Decision.PASS_WITH_CAVEATS:
                 notify_template = Config.NOTIFY_TEMPLATE_EOI_PASS_W_CAVEATS
                 contents[NotifyConstants.APPLICATION_CAVEATS] = eoi_results["caveats"]
+            case _:
+                current_app.logger.error(
+                    "Unknown eoi_decision [{eoi_decision}], unable to send submit notification",
+                    extra=dict(eoi_decision=eoi_decision),
+                )
     else:
         notify_template = Config.NOTIFY_TEMPLATE_SUBMIT_APPLICATION
 

--- a/application_store/_helpers/application.py
+++ b/application_store/_helpers/application.py
@@ -1,5 +1,19 @@
 from operator import itemgetter
 
+from flask import current_app
+from fsd_utils import Decision
+from fsd_utils.config.notify_constants import NotifyConstants
+
+from application_store.config.key_report_mappings.mappings import (
+    ROUND_ID_TO_KEY_REPORT_MAPPING,
+)
+from application_store.db.queries.application import create_qa_base64file
+from application_store.db.queries.reporting.queries import (
+    map_application_key_fields,
+)
+from application_store.external_services.models.notification import Notification
+from config import Config
+
 
 def order_applications(applications, order_by, order_rev):
     """
@@ -19,3 +33,60 @@ def order_applications(applications, order_by, order_rev):
             reverse=int(order_rev),
         )
     return applications
+
+
+def send_submit_notification(
+    application_with_form_json,
+    should_send_email,
+    eoi_results,
+    account,
+    application_with_form_json_and_fund_name,
+    application,
+    round_data,
+):
+    if eoi_results:
+        eoi_decision = eoi_results["decision"]
+        full_name = (
+            account.full_name
+            if account.full_name
+            else map_application_key_fields(
+                application_with_form_json,
+                ROUND_ID_TO_KEY_REPORT_MAPPING[application.round_id],
+                application.round_id,
+            ).get("lead_contact_name", "")
+        )
+        contents = {
+            NotifyConstants.APPLICATION_FIELD: application_with_form_json_and_fund_name,
+            NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: round_data.contact_email,
+            NotifyConstants.APPLICATION_CAVEATS: eoi_results["caveats"],
+        }
+        if Decision(eoi_decision) == Decision.PASS:  # EOI Full pass
+            notify_template = Config.NOTIFY_TEMPLATE_EOI_PASS
+
+        elif Decision(eoi_decision) == Decision.PASS_WITH_CAVEATS:  # EOI Pass with caveats
+            notify_template = Config.NOTIFY_TEMPLATE_EOI_PASS_W_CAVEATS
+        else:
+            notify_template = None
+            should_send_email = False
+    else:
+        notify_template = Config.NOTIFY_TEMPLATE_SUBMIT_APPLICATION
+        eoi_decision = None
+        full_name = account.full_name
+        contents = {
+            NotifyConstants.APPLICATION_FIELD: application_with_form_json_and_fund_name,
+            NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: round_data.contact_email,
+        }
+
+    if should_send_email:
+        contents["application"] = create_qa_base64file(contents.get("application"), True)
+        del contents["application"]["forms"]
+        message_id = Notification.send(
+            notify_template,
+            account.email,
+            full_name.title() if full_name else None,
+            contents,
+        )
+        current_app.logger.info(
+            "Message added to the queue msg_id: [{message_id}]",
+            extra=dict(message_id=message_id),
+        )

--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -214,10 +214,9 @@ class ApplicationsView(MethodView):
                     round_data=round_data,
                 )
 
-        except NotificationError as e:
+        except NotificationError:
             current_app.logger.exception(
                 "Notification error on sending SUBMIT notification for application {application_id}",
-                exc_info=e,
                 extra=dict(application_id=application_id),
             )
 

--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -1,18 +1,13 @@
-import json
 import time
 from typing import Optional
-from uuid import uuid4
 
 from flask import current_app, jsonify, request, send_file
 from flask.views import MethodView
-from fsd_utils import Decision, evaluate_response
-from fsd_utils.config.notify_constants import NotifyConstants
+from fsd_utils import evaluate_response
 from sqlalchemy.orm.exc import NoResultFound
 
 from application_store._helpers import get_blank_forms, order_applications
-from application_store.config.key_report_mappings.mappings import (
-    ROUND_ID_TO_KEY_REPORT_MAPPING,
-)
+from application_store._helpers.application import send_submit_notification
 from application_store.db.models.application.enums import Status
 from application_store.db.queries import (
     add_new_forms,
@@ -38,7 +33,6 @@ from application_store.db.queries.feedback import (
 )
 from application_store.db.queries.reporting.queries import (
     export_application_statuses_to_csv,
-    map_application_key_fields,
 )
 from application_store.db.queries.research import (
     retrieve_research_survey_data,
@@ -56,10 +50,7 @@ from application_store.external_services import (
 )
 from application_store.external_services.exceptions import (
     NotificationError,
-    SubmitError,
 )
-from application_store.external_services.models.notification import Notification
-from config import Config
 
 
 class ApplicationsView(MethodView):
@@ -200,55 +191,22 @@ class ApplicationsView(MethodView):
                 "prospectus_url": round_data.prospectus_url,
             }
 
-            self._send_submit_queue(application_id, application_with_form_json)
-
             if round_data.is_expression_of_interest:
-                full_name = (
-                    account.full_name
-                    if account.full_name
-                    else map_application_key_fields(
-                        application_with_form_json,
-                        ROUND_ID_TO_KEY_REPORT_MAPPING[application.round_id],
-                        application.round_id,
-                    ).get("lead_contact_name", "")
-                )
                 eoi_results = self.get_application_eoi_response(application_with_form_json)
                 eoi_decision = eoi_results["decision"]
-                contents = {
-                    NotifyConstants.APPLICATION_FIELD: application_with_form_json_and_fund_name,
-                    NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: round_data.contact_email,
-                    NotifyConstants.APPLICATION_CAVEATS: eoi_results["caveats"],
-                }
-                if Decision(eoi_decision) == Decision.PASS:  # EOI Full pass
-                    notify_template = Config.NOTIFY_TEMPLATE_EOI_PASS
-
-                elif Decision(eoi_decision) == Decision.PASS_WITH_CAVEATS:  # EOI Pass with caveats
-                    notify_template = Config.NOTIFY_TEMPLATE_EOI_PASS_W_CAVEATS
-                else:
-                    notify_template = None
-                    should_send_email = False
             else:
-                notify_template = Config.NOTIFY_TEMPLATE_SUBMIT_APPLICATION
+                eoi_results = None
                 eoi_decision = None
-                full_name = account.full_name
-                contents = {
-                    NotifyConstants.APPLICATION_FIELD: application_with_form_json_and_fund_name,
-                    NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: round_data.contact_email,
-                }
 
-            if should_send_email:
-                contents["application"] = create_qa_base64file(contents.get("application"), True)
-                del contents["application"]["forms"]
-                message_id = Notification.send(
-                    notify_template,
-                    account.email,
-                    full_name.title() if full_name else None,
-                    contents,
-                )
-                current_app.logger.info(
-                    "Message added to the queue msg_id: [{message_id}]",
-                    extra=dict(message_id=message_id),
-                )
+            send_submit_notification(
+                application_with_form_json=application_with_form_json,
+                should_send_email=should_send_email,
+                eoi_results=eoi_results,
+                account=account,
+                application_with_form_json_and_fund_name=application_with_form_json_and_fund_name,
+                application=application,
+                round_data=round_data,
+            )
             return {
                 "id": application_id,
                 "reference": application_with_form_json["reference"],
@@ -267,12 +225,6 @@ class ApplicationsView(MethodView):
                 extra=dict(application_id=application_id),
             )
             return str(e), 500, {"x-error": "notification error"}
-        except SubmitError as e:
-            current_app.logger.exception(
-                "Submit error on sending SUBMIT application {application_id}",
-                extra=dict(application_id=application_id),
-            )
-            return str(e), 500, {"x-error": "Submit error"}
         except Exception as e:
             current_app.logger.exception(
                 "Error on sending SUBMIT notification for application {application_id}",
@@ -280,34 +232,34 @@ class ApplicationsView(MethodView):
             )
             return str(e), 500, {"x-error": "Error"}
 
-    def _send_submit_queue(self, application_id, application_with_form_json):
-        """
-        Send message to sqs queue once application is submitted
-        """
-        application_attributes = {
-            "application_id": {"StringValue": application_id, "DataType": "String"},
-            "S3Key": {
-                "StringValue": "submit",
-                "DataType": "String",
-            },
-        }
-        try:
-            sqs_extended_client = self._get_sqs_client()
-            message_id = sqs_extended_client.submit_single_message(
-                queue_url=Config.AWS_SQS_IMPORT_APP_PRIMARY_QUEUE_URL,
-                message=json.dumps(application_with_form_json),
-                message_group_id="import_applications_group",
-                message_deduplication_id=str(uuid4()),  # ensures message uniqueness
-                extra_attributes=application_attributes,
-            )
-            current_app.logger.info(
-                "Message sent to SQS queue and message id is [{message_id}]",
-                extra=dict(message_id=message_id),
-            )
-        except Exception as e:
-            current_app.logger.error("An error occurred while sending message")
-            current_app.logger.error(e)
-            raise SubmitError(message="Sorry, cannot submit the message") from e
+    # def _send_submit_queue(self, application_id, application_with_form_json):
+    #     """
+    #     Send message to sqs queue once application is submitted
+    #     """
+    #     application_attributes = {
+    #         "application_id": {"StringValue": application_id, "DataType": "String"},
+    #         "S3Key": {
+    #             "StringValue": "submit",
+    #             "DataType": "String",
+    #         },
+    #     }
+    #     try:
+    #         sqs_extended_client = self._get_sqs_client()
+    #         message_id = sqs_extended_client.submit_single_message(
+    #             queue_url=Config.AWS_SQS_IMPORT_APP_PRIMARY_QUEUE_URL,
+    #             message=json.dumps(application_with_form_json),
+    #             message_group_id="import_applications_group",
+    #             message_deduplication_id=str(uuid4()),  # ensures message uniqueness
+    #             extra_attributes=application_attributes,
+    #         )
+    #         current_app.logger.info(
+    #             "Message sent to SQS queue and message id is [{message_id}]",
+    #             extra=dict(message_id=message_id),
+    #         )
+    #     except Exception as e:
+    #         current_app.logger.error("An error occurred while sending message")
+    #         current_app.logger.error(e)
+    #         raise SubmitError(message="Sorry, cannot submit the message") from e
 
     def post_feedback(self):
         args = request.get_json()

--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -310,12 +310,6 @@ class ApplicationsView(MethodView):
         result = evaluate_response(eoi_schema, application["forms"])
         return result
 
-    def _get_sqs_client(self):
-        sqs_extended_client = current_app.extensions["sqs_extended_client"]
-        if sqs_extended_client is not None:
-            return sqs_extended_client
-        current_app.logger.error("An error occurred while sending message since client is not available")
-
     def post_research_survey_data(self):
         """
         Endpoint to post research survey data.

--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -51,6 +51,7 @@ from application_store.external_services import (
 from application_store.external_services.exceptions import (
     NotificationError,
 )
+from assessment_store.db.queries.assessment_records.queries import insert_application_record
 
 
 class ApplicationsView(MethodView):
@@ -190,6 +191,9 @@ class ApplicationsView(MethodView):
                 "round_name": round_name,
                 "prospectus_url": round_data.prospectus_url,
             }
+            insert_application_record(
+                application_json_string=application_with_form_json, application_type=None, is_json=True
+            )
 
             if round_data.is_expression_of_interest:
                 eoi_results = self.get_application_eoi_response(application_with_form_json)

--- a/application_store/db/exceptions/__init__.py
+++ b/application_store/db/exceptions/__init__.py
@@ -1,3 +1,4 @@
 from application_store.db.exceptions.application import ApplicationError
+from application_store.db.exceptions.submit import SubmitError
 
-__all__ = ["ApplicationError"]
+__all__ = ["ApplicationError", "SubmitError"]

--- a/application_store/db/exceptions/submit.py
+++ b/application_store/db/exceptions/submit.py
@@ -1,0 +1,7 @@
+class SubmitError(Exception):
+    def __init__(self, application_id, *args):
+        super().__init__(*args)
+        self.application_id = application_id
+
+    def __str__(self):
+        return f"Unable to submit application [{self.application_id}]. Cause {self.__cause__}"

--- a/application_store/db/models/application/applications.py
+++ b/application_store/db/models/application/applications.py
@@ -42,7 +42,11 @@ class Applications(BaseModel):
     __table_args__ = (db.UniqueConstraint("fund_id", "round_id", "key", name="_reference"),)
 
     def as_dict(self):
-        date_submitted = self.date_submitted.isoformat() if self.date_submitted else "null"
+        date_submitted = (
+            (self.date_submitted if type(self.date_submitted) is str else self.date_submitted.isoformat())
+            if self.date_submitted
+            else "null"
+        )
         return {
             "id": str(self.id),
             "account_id": self.account_id,

--- a/application_store/db/queries/application/queries.py
+++ b/application_store/db/queries/application/queries.py
@@ -19,7 +19,6 @@ from application_store.db.models.application.enums import Status as ApplicationS
 from application_store.db.schemas import ApplicationSchema
 from application_store.external_services import get_fund, get_round
 from application_store.external_services.aws import FileData, list_files_by_prefix
-from assessment_store.db.queries.assessment_records.queries import insert_application_record
 from config import Config
 from db import db
 
@@ -248,8 +247,6 @@ def submit_application(application_id) -> Applications:
 
     all_application_files = list_files_by_prefix(application_id)
     application = process_files(application, all_application_files)
-
-    insert_application_record(application_json_string=application, application_type=None, is_json=True)
 
     application.status = "SUBMITTED"
     db.session.commit()

--- a/application_store/db/queries/application/queries.py
+++ b/application_store/db/queries/application/queries.py
@@ -257,7 +257,7 @@ def submit_application(application_id) -> Applications:
 
         application_type = "".join(application.reference.split("-")[:1])
 
-        application_as_dict = application.as_dict()
+        application_as_dict = get_application(application_id, include_forms=True, as_json=True)
 
         derived_values = derive_application_values(application_as_dict)
 

--- a/application_store/db/queries/application/queries.py
+++ b/application_store/db/queries/application/queries.py
@@ -19,6 +19,7 @@ from application_store.db.models.application.enums import Status as ApplicationS
 from application_store.db.schemas import ApplicationSchema
 from application_store.external_services import get_fund, get_round
 from application_store.external_services.aws import FileData, list_files_by_prefix
+from assessment_store.db.queries.assessment_records.queries import insert_application_record
 from config import Config
 from db import db
 
@@ -247,6 +248,8 @@ def submit_application(application_id) -> Applications:
 
     all_application_files = list_files_by_prefix(application_id)
     application = process_files(application, all_application_files)
+
+    insert_application_record(application_json_string=application, application_type=None, is_json=True)
 
     application.status = "SUBMITTED"
     db.session.commit()

--- a/application_store/external_services/exceptions.py
+++ b/application_store/external_services/exceptions.py
@@ -11,18 +11,3 @@ class NotificationError(Exception):
     ):
         self.message = message
         super().__init__(self.message)
-
-
-class SubmitError(Exception):
-    """Exception raises an an error
-
-    Attributes:
-        message -- explanation of the error
-    """
-
-    def __init__(
-        self,
-        message="Sorry, there was a problem posting to the assessment service",  # noqa
-    ):
-        self.message = message
-        super().__init__(self.message)

--- a/assessment_store/db/queries/__init__.py
+++ b/assessment_store/db/queries/__init__.py
@@ -3,7 +3,6 @@ from .assessment_records.queries import (
     delete_assessment_record,
     find_answer_by_key_runner,
     get_metadata_for_fund_round_id,
-    insert_application_record,
 )
 from .comments.queries import create_comment, get_comments_from_db
 from .progress.queries import get_progress_for_app
@@ -20,7 +19,6 @@ __all__ = [
     "insert_tags",
     "get_metadata_for_fund_round_id",
     "bulk_insert_application_record",
-    "insert_application_record",
     "find_answer_by_key_runner",
     "get_scores_for_app_sub_crit",
     "create_score_for_app_sub_crit",

--- a/assessment_store/db/queries/assessment_records/_helpers.py
+++ b/assessment_store/db/queries/assessment_records/_helpers.py
@@ -174,8 +174,9 @@ def derive_application_values(application_json):  # noqa: C901 - historical sadn
         location_data = None
         if address_key := field_mappings["location"]:
             address = get_answer_value(application_json, address_key)
-            raw_postcode = address.split(",")[-1].strip().replace(" ", "").upper()
-            location_data = get_location_json_from_postcode(raw_postcode)
+            if address:
+                raw_postcode = address.split(",")[-1].strip().replace(" ", "").upper()
+                location_data = get_location_json_from_postcode(raw_postcode)
 
         derived_values["funding_amount_requested"] = funding_one + funding_two
         derived_values["asset_type"] = asset_type
@@ -183,7 +184,7 @@ def derive_application_values(application_json):  # noqa: C901 - historical sadn
             derived_values["location_json_blob"] = location_data
         else:
             derived_values["location_json_blob"]["error"] = (
-                True if fund_round_data_key_mappings[fund_round_shortname]["location"] else False
+                True if address_key else False
             )  # if location is not mandatory for a fund, then treat error as `False`
     except Exception as e:
         current_app.logger.error(

--- a/assessment_store/db/queries/assessment_records/_helpers.py
+++ b/assessment_store/db/queries/assessment_records/_helpers.py
@@ -35,6 +35,7 @@ def get_answer_value_for_multi_input(application_json, answer_key, value_key):
 def get_location_json_from_postcode(raw_postcode):
     """Make a POST request to the postcodes.io API with the provided postcode and
     extract the location data of postcode."""
+    # TODO make this more robust and deal with failures
     result = requests.post(
         url="http://api.postcodes.io/postcodes",
         json={"postcodes": [raw_postcode]},

--- a/assessment_store/db/queries/assessment_records/_helpers.py
+++ b/assessment_store/db/queries/assessment_records/_helpers.py
@@ -10,148 +10,189 @@ from assessment_store.config.mappings.assessment_mapping_fund_round import (
 )
 from assessment_store.db.models.assessment_record import TagAssociation
 
+FIELD_DEFAULT_VALUE = "Not Available"
+
 
 def get_answer_value(application_json, answer_key):
-    return (
-        jsonpath_rw_ext.parse(f"$.forms[*].questions[*].fields[?(@.key == '{answer_key}')]")
-        .find(application_json)[0]
-        .value["answer"]
-    )
+    try:
+        return (
+            jsonpath_rw_ext.parse(f"$.forms[*].questions[*].fields[?(@.key == '{answer_key}')]")
+            .find(application_json)[0]
+            .value["answer"]
+        )
+    except Exception as e:
+        current_app.logger.warning(
+            "Could not extract answer from question {answer_key} in application: {application_id}.",
+            extra=dict(application_id=application_json["id"], answer_key=answer_key),
+            exc_info=e,
+        )
+        return None
 
 
 def get_answer_value_for_multi_input(application_json, answer_key, value_key):
-    answers = (
-        jsonpath_rw_ext.parse(f"$.forms[*].questions[*].fields[?(@.key == '{answer_key}')]")
-        .find(application_json)[0]
-        .value["answer"]
-    )
+    try:
+        answers = (
+            jsonpath_rw_ext.parse(f"$.forms[*].questions[*].fields[?(@.key == '{answer_key}')]")
+            .find(application_json)[0]
+            .value["answer"]
+        )
 
-    funding_one = 0
-    for answer in answers:
-        funding_one = funding_one + int(float(answer[value_key]))
-    return funding_one
+        funding_one = 0
+        for answer in answers:
+            funding_one = funding_one + int(float(answer[value_key]))
+        return funding_one
+    except Exception as e:
+        current_app.logger.warning(
+            "Could not extract answer from question {answer_key} in application: {application_id}.",
+            extra=dict(application_id=application_json["id"], answer_key=answer_key),
+            exc_info=e,
+        )
+        return None
 
 
 def get_location_json_from_postcode(raw_postcode):
     """Make a POST request to the postcodes.io API with the provided postcode and
     extract the location data of postcode."""
-    # TODO make this more robust and deal with failures
-    result = requests.post(
-        url="http://api.postcodes.io/postcodes",
-        json={"postcodes": [raw_postcode]},
-        headers={"Content-Type": "application/json"},
-    ).json()
+    try:
+        response = requests.post(
+            url="http://api.postcodes.io/postcodes",
+            json={"postcodes": [raw_postcode]},
+            headers={"Content-Type": "application/json"},
+        )
+        if response.status_code != 200:
+            current_app.logger.error(
+                "Failed requesting location data for postcode {postcode}. Received error response {response}",
+                extra=dict(postcode=raw_postcode, response=response),
+            )
+            return None
 
-    postcode_data = result["result"][0]["result"]
-    location_data = (
-        {
-            "error": False,
-            "postcode": raw_postcode,
-            "county": postcode_data["admin_county"]
-            if postcode_data["admin_county"]
-            else postcode_data["admin_district"],
-            "region": postcode_data["region"]
-            if postcode_data["region"]
-            else postcode_data["european_electoral_region"],
-            "country": postcode_data["country"],
-            "constituency": postcode_data["parliamentary_constituency"],
-        }
-        if postcode_data
-        else None
-    )
-    return location_data
+        result = response.json()
+        postcode_data = result["result"][0]["result"]
+        location_data = (
+            {
+                "error": False,
+                "postcode": raw_postcode,
+                "county": postcode_data["admin_county"]
+                if postcode_data["admin_county"]
+                else postcode_data["admin_district"],
+                "region": postcode_data["region"]
+                if postcode_data["region"]
+                else postcode_data["european_electoral_region"],
+                "country": postcode_data["country"],
+                "constituency": postcode_data["parliamentary_constituency"],
+            }
+            if postcode_data
+            else None
+        )
+        return location_data
+
+    except Exception as e:
+        current_app.logger.error(
+            "Failed requesting location data for postcode {postcode}", exc_info=e, extra=dict(postcode=raw_postcode)
+        )
+        return None
 
 
 def derive_application_values(application_json):  # noqa: C901 - historical sadness
     # TODO: implement mapping function to match
     #  fund+round fields to derived values
-    derived_values = {}
     application_id = application_json["id"]
-    print(f"deriving values for application id: {application_id}.")
     fund_round_shortname = "".join(application_json["reference"].split("-")[:2])
+    derived_values = {
+        "application_id": application_id,
+        "project_name": ""
+        if application_json["project_name"] is None and fund_round_shortname == "COFEOI"
+        else application_json["project_name"],
+        "short_id": application_json["reference"],
+        "fund_id": application_json["fund_id"],
+        "round_id": application_json["round_id"],
+        "funding_amount_requested": 0,
+        "asset_type": "No asset type specified.",
+        "language": application_json["language"],
+        "location_json_blob": {
+            "error": False,
+            "postcode": FIELD_DEFAULT_VALUE,
+            "county": FIELD_DEFAULT_VALUE,
+            "region": FIELD_DEFAULT_VALUE,
+            "country": FIELD_DEFAULT_VALUE,
+            "constituency": FIELD_DEFAULT_VALUE,
+        },
+    }
 
-    # search for asset_type
+    field_mappings = fund_round_data_key_mappings.get(fund_round_shortname, None)
+    if not field_mappings:
+        # Don't throw an exception here as we want to soft-fail - ie the submission process still works, but devs are
+        # alerted to the lack of mappings
+        current_app.logger.error(
+            "No assessment data mappings for fund round [fund_round_shortname]. "
+            "Cannot derive values for application [application_id]",
+            extra=dict(fund_round_shortname=fund_round_shortname, application_id=application_id),
+        )
+        return derived_values
+
+    # Some funds don't map any fields, so don't bother with the rest of this function if that's the case
+    if all(field is None for field in field_mappings.values()):
+        return derived_values
+
+    current_app.logger.info(
+        "Deriving values for application id: {application_id}.", extra=dict(application_id=application_id)
+    )
+
     try:
+        # search for asset_type
         asset_type = "No asset type specified."
-        if asset_key := fund_round_data_key_mappings[fund_round_shortname]["asset_type"]:
-            asset_type = get_answer_value(application_json, asset_key)
-    except Exception:
-        print(f"Could not extract asset_type from application: {application_id}.")
+        if asset_key := field_mappings["asset_type"]:
+            asset_type = get_answer_value(application_json, asset_key) or FIELD_DEFAULT_VALUE
 
-    # search for capital funding
-    funding_field_type = fund_round_data_key_mappings.get(fund_round_shortname, {}).get("funding_field_type")
-    try:
+        # search for capital funding
+        funding_field_type = fund_round_data_key_mappings.get(fund_round_shortname, {}).get("funding_field_type")
         funding_one = 0
-        if funding_one_keys := fund_round_data_key_mappings[fund_round_shortname]["funding_one"]:
+        if funding_one_keys := field_mappings["funding_one"]:
             funding_one_keys = [funding_one_keys] if isinstance(funding_one_keys, str) else funding_one_keys
 
             if funding_field_type == "multiInputField" and len(funding_one_keys) > 1:
-                funding_one = get_answer_value_for_multi_input(
-                    application_json, funding_one_keys[0], funding_one_keys[1]
+                funding_one = (
+                    get_answer_value_for_multi_input(application_json, funding_one_keys[0], funding_one_keys[1]) or 0
                 )
             else:
                 for key in funding_one_keys:
-                    funding_one = funding_one + int(float(get_answer_value(application_json, key)))
+                    funding_one = funding_one + int(float(get_answer_value(application_json, key) or 0))
 
-    except Exception:
-        print("Could not extract funding_value_one from application: " + f"{application_id}.")
-
-    # search for revenue funding
-    try:
+        # search for revenue funding
         funding_two = 0
-        if funding_two_keys := fund_round_data_key_mappings[fund_round_shortname]["funding_two"]:
+        if funding_two_keys := field_mappings["funding_two"]:
             funding_two_keys = [funding_two_keys] if isinstance(funding_two_keys, str) else funding_two_keys
             if funding_field_type == "multiInputField" and len(funding_two_keys) > 1:
-                funding_two = get_answer_value_for_multi_input(
-                    application_json, funding_two_keys[0], funding_two_keys[1]
+                funding_two = (
+                    get_answer_value_for_multi_input(application_json, funding_two_keys[0], funding_two_keys[1]) or 0
                 )
             else:
                 for key in funding_two_keys:
-                    funding_two = funding_two + int(float(get_answer_value(application_json, key)))
-    except Exception:
-        print("Could not extract funding_value_two from application: " + f"{application_id}.")
+                    funding_two = funding_two + int(float(get_answer_value(application_json, key) or 0))
 
-    # search for location postcode
-    try:
-        location_data = ""
-        if address_key := fund_round_data_key_mappings[fund_round_shortname]["location"]:
+        # search for location postcode
+        location_data = None
+        if address_key := field_mappings["location"]:
             address = get_answer_value(application_json, address_key)
             raw_postcode = address.split(",")[-1].strip().replace(" ", "").upper()
             location_data = get_location_json_from_postcode(raw_postcode)
-            if not location_data:
-                print(f"Invalid postcode '{raw_postcode}' provided for the application: {application_id}.")
-    except Exception:
-        print("Could not extract address from application: " + f"{application_id}.")
 
-    derived_values["application_id"] = application_id
-    if application_json["project_name"] is None and fund_round_shortname == "COFEOI":
-        derived_values["project_name"] = (
-            ""  # EOI does not have a project name form compoent. Maybe this has to become nullable?
+        derived_values["funding_amount_requested"] = funding_one + funding_two
+        derived_values["asset_type"] = asset_type
+        if location_data:
+            derived_values["location_json_blob"] = location_data
+        else:
+            derived_values["location_json_blob"]["error"] = (
+                True if fund_round_data_key_mappings[fund_round_shortname]["location"] else False
+            )  # if location is not mandatory for a fund, then treat error as `False`
+    except Exception as e:
+        current_app.logger.error(
+            # Shouldn't ever get here, but quick catch all for the interim removal of the queue
+            # and not breaking the submit process
+            "Unexpected error when deriving values for application {application_id}",
+            exc_info=e,
+            extra=dict(application_id=application_id),
         )
-    else:
-        derived_values["project_name"] = application_json["project_name"]
-
-    derived_values["short_id"] = application_json["reference"]
-    derived_values["fund_id"] = application_json["fund_id"]
-    derived_values["round_id"] = application_json["round_id"]
-    derived_values["funding_amount_requested"] = funding_one + funding_two
-    derived_values["asset_type"] = asset_type
-    derived_values["language"] = application_json["language"]
-    if location_data:
-        derived_values["location_json_blob"] = location_data
-    else:
-        derived_values["location_json_blob"] = {
-            "error": True
-            if fund_round_data_key_mappings[fund_round_shortname]["location"]
-            else False  # if location is not mandatory for a fund, then treat error as `False`
-        }
-
-        FIELD_DEFAULT_VALUE = "Not Available"
-        derived_values["location_json_blob"]["county"] = FIELD_DEFAULT_VALUE
-        derived_values["location_json_blob"]["region"] = FIELD_DEFAULT_VALUE
-        derived_values["location_json_blob"]["country"] = FIELD_DEFAULT_VALUE
-        derived_values["location_json_blob"]["constituency"] = FIELD_DEFAULT_VALUE
-        derived_values["location_json_blob"]["postcode"] = FIELD_DEFAULT_VALUE
 
     return derived_values
 

--- a/assessment_store/db/queries/assessment_records/queries.py
+++ b/assessment_store/db/queries/assessment_records/queries.py
@@ -327,51 +327,6 @@ def bulk_insert_application_record(
     return rows
 
 
-def insert_application_record(application_json_string: str, application_type: str, is_json=False) -> AssessmentRecord:
-    """insert_application_record Given a json strings and an `application_type` we
-    extract key values from the json strings before inserting them with the
-    remaining values into `db.models.AssessmentRecord`.
-
-    :param application_json_string: _description_
-    :param application_type: _description_
-
-    """
-    if not is_json:
-        application_json_string = json.loads(application_json_string)
-
-    if not application_type:
-        application_type = "".join(application_json_string["reference"].split("-")[:1])
-
-    derived_values = derive_application_values(application_json_string)
-
-    row = {
-        **derived_values,
-        "jsonb_blob": application_json_string,
-        "type_of_application": application_type,
-    }
-    try:
-        stmt = postgres_insert(AssessmentRecord).values([row])
-
-        upsert_rows_stmt = stmt.on_conflict_do_nothing(index_elements=[AssessmentRecord.application_id]).returning(
-            AssessmentRecord.application_id
-        )
-
-        print(f"Attempting insert of application {row['application_id']}")
-        result = db.session.execute(upsert_rows_stmt)
-
-        # Check if the inserted application is in result
-        inserted_application_ids = [item.application_id for item in result]
-        if not len(inserted_application_ids):
-            print(f"Application id already exist in the database: {row['application_id']}")
-        else:
-            print(f"Successfully inserted application_id  : {row['application_id']} ")
-        db.session.commit()
-    except exc.SQLAlchemyError as e:
-        db.session.rollback()
-        print(f"Error occurred while inserting application {row['application_id']}, error: {e}")
-    return row
-
-
 def delete_assessment_record(app_id):
     """Delete the assessment record with the given ID from the database.
 

--- a/tests/application_store_tests/conftest.py
+++ b/tests/application_store_tests/conftest.py
@@ -283,6 +283,7 @@ def mock_get_round(mocker):
     """
     mocker.patch("application_store.db.queries.application.queries.get_round", new=generate_mock_round)
     mocker.patch("application_store.db.queries.statuses.queries.get_round", new=generate_mock_round)
+    mocker.patch("application_store.api.routes.application.routes.get_round", new=generate_mock_round)
     mocker.patch(
         "application_store.db.schemas.application.get_round_name",
         return_value="Generated test round",

--- a/tests/application_store_tests/conftest.py
+++ b/tests/application_store_tests/conftest.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from uuid import uuid4
 
 import pytest
-from flask import Response
 
 from app import create_app
 from application_store.db.models.application.applications import Applications
@@ -309,8 +308,8 @@ def mock_random_choices(mocker):
 def mock_successful_submit_notification(mocker):
     # mock the function in the file it is invoked (not where it is declared)
     mocker.patch(
-        "application_store.api.routes.application.routes.Notification.send",
-        lambda template, email, full_name, application: Response(200),
+        "application_store.api.routes.application.routes.send_submit_notification",
+        return_value=None,
     )
 
 

--- a/tests/application_store_tests/seed_data/COF_R4W2_all_forms.json
+++ b/tests/application_store_tests/seed_data/COF_R4W2_all_forms.json
@@ -1,0 +1,1508 @@
+{
+    "id": "0260c133-f544-48bb-a9a3-33562020f47b",
+    "forms": [
+        {
+            "name": "organisation-information-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "WWWWxy",
+                            "type": "text",
+                            "title": "Your expression of interest (EOI) application reference",
+                            "answer": "ANON-###-###-###"
+                        },
+                        {
+                            "key": "YdtlQZ",
+                            "type": "text",
+                            "title": "Organisation name",
+                            "answer": "Muller, Cremin and Quigley"
+                        },
+                        {
+                            "key": "iBCGxY",
+                            "type": "list",
+                            "title": "Does your organisation use any other names?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Organisation names"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "PHFkCs",
+                            "type": "text",
+                            "title": "Alternative names of your organisation",
+                            "answer": "Muller, Cremin and Quigley"
+                        },
+                        {
+                            "key": "QgNhXX",
+                            "type": "text",
+                            "title": "Alternative names of your organisation - Alternative name 2 ",
+                            "answer": null
+                        },
+                        {
+                            "key": "XCcqae",
+                            "type": "text",
+                            "title": "Alternative names of your organisation - Alternative name 3 ",
+                            "answer": null
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Alternative names of your organisation"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "emVGxS",
+                            "type": "freeText",
+                            "title": "What is your organisation's main purpose?",
+                            "answer": "<p>Test Org Form</p>"
+                        },
+                        {
+                            "key": "btTtIb",
+                            "type": "freeText",
+                            "title": "Tell us about your organisation's main activities",
+                            "answer": "<p>Test Org Form</p>"
+                        },
+                        {
+                            "key": "SkocDi",
+                            "type": "freeText",
+                            "title": "Tell us about your organisation's main activities - Activity 2 ",
+                            "answer": null
+                        },
+                        {
+                            "key": "CNeeiC",
+                            "type": "freeText",
+                            "title": "Tell us about your organisation's main activities - Activity 3 ",
+                            "answer": null
+                        },
+                        {
+                            "key": "BBlCko",
+                            "type": "list",
+                            "title": "Have you delivered projects like this before?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Purpose and activities"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "wxCszQ",
+                            "type": "freeText",
+                            "title": "Describe your previous projects",
+                            "answer": "<p>Test Org Form</p>"
+                        },
+                        {
+                            "key": "QJFQgi",
+                            "type": "freeText",
+                            "title": "Describe your previous projects - Project 2 ",
+                            "answer": null
+                        },
+                        {
+                            "key": "DGNWqE",
+                            "type": "freeText",
+                            "title": "Describe your previous projects - Project 3 ",
+                            "answer": null
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Previous projects similar to this one"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "lajFtB",
+                            "type": "list",
+                            "title": "Type of organisation",
+                            "answer": "Trust port"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "How your organisation is classified"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "GlPmCX",
+                            "type": "text",
+                            "title": "Company registration number",
+                            "answer": "3680065952888946"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Company registration details"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "GvPSna",
+                            "type": "list",
+                            "title": "Which regulatory body is your company registered with?",
+                            "answer": "Companies House"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Registration details"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "DwfHtk",
+                            "type": "list",
+                            "title": "Is your organisation a trading subsidiary of a parent company?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Trading subsidiaries"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "MPNlZx",
+                            "type": "text",
+                            "title": "Name of parent organisation",
+                            "answer": "Muller, Cremin and Quigley"
+                        },
+                        {
+                            "key": "MyiYMw",
+                            "type": "date",
+                            "title": "Date parent organisation was established",
+                            "answer": "2024-01-01"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Parent organisation details"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "ZQolYb",
+                            "type": "text",
+                            "title": "Organisation address",
+                            "answer": "9 Josiane Approach, Birchett Road, Batz Place, Hampshire, GU11 1LY"
+                        },
+                        {
+                            "key": "zsoLdf",
+                            "type": "list",
+                            "title": "Is your correspondence address different to the organisation address?",
+                            "answer": false
+                        },
+                        {
+                            "key": "FhbaEy",
+                            "type": "text",
+                            "title": "Website and social media",
+                            "answer": "https://twitter.com/luhc"
+                        },
+                        {
+                            "key": "FcdKlB",
+                            "type": "text",
+                            "title": "Website and social media - Link or username 2",
+                            "answer": null
+                        },
+                        {
+                            "key": "BzxgDA",
+                            "type": "text",
+                            "title": "Website and social media - Link or username 3",
+                            "answer": null
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Organisation address"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "hnLurH",
+                            "type": "list",
+                            "title": "Is your application a joint bid in partnership with other organisations?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Joint applications"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "APSjeB",
+                            "type": "text",
+                            "title": "Partner organisation name",
+                            "answer": "Muller, Cremin and Quigley"
+                        },
+                        {
+                            "key": "biTJjF",
+                            "type": "text",
+                            "title": "Partner organisation address",
+                            "answer": "9 Josiane Approach, Birchett Road, Batz Place, Hampshire, GU11 1LY"
+                        },
+                        {
+                            "key": "IkmvEt",
+                            "type": "freeText",
+                            "title": "Tell us about your partnership and how you plan to work together",
+                            "answer": "<p>Test Org Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "JBqDtK",
+                    "question": "Partner organisation details"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "project-information-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "pWwCRM",
+                            "type": "list",
+                            "title": "Have you applied to the Community Ownership Fund before?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "qsnIGd",
+                    "question": "Previous Community Ownership Fund applications"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "paawsj",
+                            "type": "list",
+                            "title": "Was your application successful?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "qsnIGd",
+                    "question": "Successful Community Ownership Fund applications"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "ACppgI",
+                            "type": "freeText",
+                            "title": "Describe the project for which you were given funding",
+                            "answer": "<p>Test Project Information Form</p>"
+                        },
+                        {
+                            "key": "yuvajR",
+                            "type": "text",
+                            "title": "Amount of funding received",
+                            "answer": "12"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "qsnIGd",
+                    "question": "Projects previously funded by the Community Ownership Fund"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "apGjFS",
+                            "type": "text",
+                            "title": "Project name",
+                            "answer": "Community Ownership Fund E2E Journey Ortiz, Lakin and Gutkowski Project "
+                        },
+                        {
+                            "key": "bEWpAj",
+                            "type": "freeText",
+                            "title": "Tell us how the asset is currently being used, or how it has been used before, and why it's important to the community",
+                            "answer": "<p>Test Project Information Form</p>"
+                        },
+                        {
+                            "key": "uypCNM",
+                            "type": "freeText",
+                            "title": "Give a brief summary of your project, including what you hope to achieve",
+                            "answer": "<p>Test Project Information Form</p>"
+                        },
+                        {
+                            "key": "AgeRbd",
+                            "type": "freeText",
+                            "title": "Tell us about the planned activities and/or services that will take place in the asset",
+                            "answer": "<p>Test Project Information Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "qsnIGd",
+                    "question": "Project name and summary"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "EfdliG",
+                            "type": "text",
+                            "title": "Address of the community asset",
+                            "answer": "919 Carlo Grove, Birchett Road, Little Kutch, Hampshire, GU11 1LY"
+                        },
+                        {
+                            "key": "fIEUcb",
+                            "type": "text",
+                            "title": " In which constituency is your asset?",
+                            "answer": "Aldershot"
+                        },
+                        {
+                            "key": "SWfcTo",
+                            "type": "text",
+                            "title": "In which local council area is your asset?",
+                            "answer": "Rushmoor"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "qsnIGd",
+                    "question": "Address of the asset"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "applicant-information-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "SnLGJE",
+                            "type": "text",
+                            "title": "Name oflead contact",
+                            "answer": "Wilhelmine"
+                        },
+                        {
+                            "key": "qRDTUc",
+                            "type": "text",
+                            "title": "Lead contact job title",
+                            "answer": "Chief Usability Coordinator"
+                        },
+                        {
+                            "key": "NlHSBg",
+                            "type": "text",
+                            "title": "Lead contact email address",
+                            "answer": "Judd.Rempel50@yahoo.com"
+                        },
+                        {
+                            "key": "FhBkJQ",
+                            "type": "text",
+                            "title": "Lead contact telephone number",
+                            "answer": "0161 289 0881"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "ZuHuGk",
+                    "question": "Lead contact details"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "risk-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "EODncR",
+                            "type": "text",
+                            "title": "Risks to your project (document upload)",
+                            "answer": "sample.txt"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "HKdODf",
+                    "question": "Your project risk register"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "upload-business-plan-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "ndpQJk",
+                            "type": "text",
+                            "title": "Upload business plan",
+                            "answer": "sample.txt"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "xtwqlH",
+                    "question": "Your business plan"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "community-representation-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "ReomFo",
+                            "type": "freeText",
+                            "title": "List the members of your board",
+                            "answer": "<p>Test Community Representation Form</p>"
+                        },
+                        {
+                            "key": "fjVmOt",
+                            "type": "freeText",
+                            "title": "Tell us about your governance and membership structures",
+                            "answer": "<p>Test Community Representation Form</p>"
+                        },
+                        {
+                            "key": "GETNxN",
+                            "type": "freeText",
+                            "title": "Explain how you'll consider the views of the community in the running of the asset",
+                            "answer": "<p>Test Community Representation Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "KbnmOO",
+                    "question": "How you’ll run the asset"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "funding-required-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "ABROnB",
+                            "type": "text",
+                            "title": "Capital funding request",
+                            "answer": "762"
+                        },
+                        {
+                            "key": "hJkmBS",
+                            "type": "list",
+                            "title": "If successful,will you use your funding in the next 12 months?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "Capital funding request"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "qQLyXL",
+                            "type": "multiInput",
+                            "title": "Capital costs",
+                            "answer": [
+                                {
+                                    "GLQlOh": "Capital Funding",
+                                    "JtwkMy": 762,
+                                    "LeTLDo": 762,
+                                    "pHZDWT": 762
+                                }
+                            ]
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "Capital costs for your project"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "DOvZvB",
+                            "type": "list",
+                            "title": "Have you secured any match funding yet?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "If you've secured match funding"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "MopCmv",
+                            "type": "multiInput",
+                            "title": "Secured match funding",
+                            "answer": [
+                                {
+                                    "JKqLWU": "Secured Match Funding",
+                                    "LVJcDC": 762
+                                }
+                            ]
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "Secured match funding"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "HgpNUe",
+                            "type": "list",
+                            "title": "Have you already spent the match funding you have secured?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "Have you already spent the match funding you have secured?"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "DmgsiG",
+                            "type": "list",
+                            "title": "Have you identified, but not yet secured, any additional match funding?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "If you’ve identified further match funding"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "vEOdBS",
+                            "type": "multiInput",
+                            "title": "Unsecured match funding",
+                            "answer": [
+                                {
+                                    "THOdae": 762,
+                                    "iMJdfs": "Unsecured Match Funding"
+                                }
+                            ]
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "Unsecured match funding"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "matkNH",
+                            "type": "list",
+                            "title": "Are you applying for revenue funding from the Community Ownership Fund? (optional)",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "Revenue funding"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "tSKhQQ",
+                            "type": "multiInput",
+                            "title": "Revenue costs (optional)",
+                            "answer": [
+                                {
+                                    "UyaAHw": 762,
+                                    "hGsUaZ": "Revenue Costs"
+                                }
+                            ]
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "Revenue costs (optional)"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "XPDbsl",
+                            "type": "freeText",
+                            "title": "Tell us how the revenue funding you've requested will help run the asset",
+                            "answer": "<p>Tell us how the revenue funding you've requested will help run the asset</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bgUGuD",
+                    "question": "How you'll use revenue funding"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "skills-and-resources-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "XXGyzn",
+                            "type": "freeText",
+                            "title": "Describe any relevant experience you have delivering similar projects or running an asset",
+                            "answer": "<p>Test Skills And Resources Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "eLpYFr",
+                    "question": "Your experience running similar assets"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "Uaeyae",
+                            "type": "list",
+                            "title": "Do you have plans to recruit people to help you run the asset?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "eLpYFr",
+                    "question": "Recruitment plans"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "yHXVSA",
+                            "type": "freeText",
+                            "title": "Tells us about the roles you'll recruit",
+                            "answer": "<p>Test Skills And Resources Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "eLpYFr",
+                    "question": "Roles you’ll recruit to help you run the asset"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "inclusiveness-and-integration-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "mgIesb",
+                            "type": "freeText",
+                            "title": "Tell us how the asset will be accountable to local people, and involve them in its running",
+                            "answer": "<p>Test Inclusiveness and Integration Form</p>"
+                        },
+                        {
+                            "key": "lQEkep",
+                            "type": "freeText",
+                            "title": "Describe anything that might prevent people from using the asset or participating in its running",
+                            "answer": "<p>Test Inclusiveness and Integration Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "eCZBSV",
+                    "question": "How you’ll make the asset inclusive"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "asset-information-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "oXGwlA",
+                            "type": "list",
+                            "title": "Asset type",
+                            "answer": "cinema"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "How the asset is used in the community"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "LaxeJN",
+                            "type": "list",
+                            "title": "How do you intend to take community ownership of the asset?",
+                            "answer": "buy-the-asset"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "The asset in community ownership"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "tTOrEp",
+                            "type": "text",
+                            "title": "Please upload evidence that shows the asset valuation (if you are buying the asset) or the lease agreement (if you are leasing the asset).",
+                            "answer": "sample.txt"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Upload asset valuation or lease agreement"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "wAUFqr",
+                            "type": "list",
+                            "title": "Do you know who currently owns your asset?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Who owns the asset"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "FOURVe",
+                            "type": "text",
+                            "title": "Name of current asset owner",
+                            "answer": "Laura White"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Who currently owns your asset"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "XPcbJx",
+                            "type": "freeText",
+                            "title": "Describe the expected sale process, or the proposed terms of your lease if you are planning to rent the asset",
+                            "answer": "<p>Test Asset Information Form</p>"
+                        },
+                        {
+                            "key": "jGjScT",
+                            "type": "date",
+                            "title": "Expected date of sale or lease",
+                            "answer": "2022-12-01"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Expected terms of your ownership or lease"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "VGXXyq",
+                            "type": "list",
+                            "title": "Is your assetcurrently publicly owned?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Public ownership"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "rNYmXq",
+                            "type": "text",
+                            "title": "Tell us about the person you have spoken to at the relevant public body about the asset",
+                            "answer": "Laura White"
+                        },
+                        {
+                            "key": "SiOmZn",
+                            "type": "text",
+                            "title": "Job title of contact",
+                            "answer": "Product Branding Planner"
+                        },
+                        {
+                            "key": "XXVXuj",
+                            "type": "text",
+                            "title": "Organisation name",
+                            "answer": "Collins, Emard and Bernier"
+                        },
+                        {
+                            "key": "MIqglh",
+                            "type": "list",
+                            "title": "When you buy or lease a publicly owned asset, the public authority cannot transfer statutory services or duties to the community group.",
+                            "answer": [
+                                "confirm"
+                            ]
+                        },
+                        {
+                            "key": "JdEmqn",
+                            "type": "list",
+                            "title": "Grants from this fund cannot be used to buy the freehold or premium on the lease of a publicly owned asset. Money must only be used for renovation and refurbishment costs",
+                            "answer": [
+                                "confirm"
+                            ]
+                        },
+                        {
+                            "key": "RFTloT",
+                            "type": "text",
+                            "title": "Upload evidence to confirm the above information and that the asset is at risk",
+                            "answer": "sample.txt"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Public ownership details and declarations"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "qlqyUq",
+                            "type": "list",
+                            "title": "Why is the asset at risk of closure?",
+                            "answer": [
+                                "Sale",
+                                "Listed for disposal"
+                            ]
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Risk of closure"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "QPIPjx",
+                            "type": "date",
+                            "title": "When was the asset listed?",
+                            "answer": "2022-12-01"
+                        },
+                        {
+                            "key": "OJWGGr",
+                            "type": "text",
+                            "title": "Provide a link to the listing",
+                            "answer": "https://twitter.com/luhc"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Asset listing details"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "iqnlTk",
+                            "type": "list",
+                            "title": "Is this a registered Asset of Community Value (ACV)?",
+                            "answer": false
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Assets of community value"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "mZwrmI",
+                            "type": "list",
+                            "title": "Are there assets or services of a similar type available locally?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Local service provision"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "BfgLCc",
+                            "type": "list",
+                            "title": "Is your asset different from what is available locally?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Local service provision"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "WTZoVD",
+                            "type": "freeText",
+                            "title": "Tell us how and why your asset or the service is different",
+                            "answer": "<p>Test Asset Information Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Local service provision"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "GEJNWF",
+                            "type": "freeText",
+                            "title": "How accessible is the closest asset or service?",
+                            "answer": "<p>Test Asset Information Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Local service provision"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "CFFsxV",
+                            "type": "list",
+                            "title": "Does part of yourproject include a commercial aspect?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Local service provision"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "FDZQTQ",
+                            "type": "freeText",
+                            "title": "Tell us how the commercial aspect relates to the other services youprovide",
+                            "answer": "<p>Test Asset Information Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "wxYZcT",
+                    "question": "Local service provision"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "community-engagement-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "azCutK",
+                            "type": "freeText",
+                            "title": "Tell us how you have engaged with the community aboutyour intention to take ownership of the asset",
+                            "answer": "<p>Test Community Engagement Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "lmdhVN",
+                    "question": "How you've engaged with the community"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "jAhuWN",
+                            "type": "freeText",
+                            "title": "Describe your fundraising activities",
+                            "answer": "<p>Test Community Engagement Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "lmdhVN",
+                    "question": "Your fundraising activities"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "HYsezC",
+                            "type": "freeText",
+                            "title": "Tell us about any partnerships you've formed, and how they'll help the project be successful",
+                            "answer": "<p>Test Community Engagement Form</p>"
+                        },
+                        {
+                            "key": "GGBgBY",
+                            "type": "freeText",
+                            "title": "Tell us how your project supports any wider local plans",
+                            "answer": "<p>Test Community Engagement Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "lmdhVN",
+                    "question": "Partnerships and local plans"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "community-benefits-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "pqYxJO",
+                            "type": "list",
+                            "title": "What community benefits do you expect to deliver with this project?",
+                            "answer": [
+                                "community-pride"
+                            ]
+                        },
+                        {
+                            "key": "lgfiGB",
+                            "type": "freeText",
+                            "title": "Tell us about these benefits in detail, and how the asset's activities will help deliver them",
+                            "answer": "<p>Test Community Benefits Form</p>"
+                        },
+                        {
+                            "key": "zKKouR",
+                            "type": "freeText",
+                            "title": "Explain how you plan to deliver and sustainthese benefits over time",
+                            "answer": "<p>Test Community Benefits Form</p>"
+                        },
+                        {
+                            "key": "ZyIQGI",
+                            "type": "freeText",
+                            "title": "Tell us how you'll make sure the whole community benefits from the asset",
+                            "answer": "<p>Test Community Benefits Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "PTOBPV",
+                    "question": "Benefits you'll deliver"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "local-support-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "tDVPnl",
+                            "type": "freeText",
+                            "title": "Tell us about the local support for your project",
+                            "answer": "<p>Tell us about the local support for your project</p>"
+                        },
+                        {
+                            "key": "bDWjTN",
+                            "type": "text",
+                            "title": "Upload supporting evidence (optional)",
+                            "answer": null
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "apkBSm",
+                    "question": "Your support for the project"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "operational-costs-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "qXNkfr",
+                            "type": "freeText",
+                            "title": "Summarise your income and operational costs for the running of the asset",
+                            "answer": "<p>Summarise your income and operational costs for the running of the asset</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "oSfXFZ",
+                    "question": "Forecasted income and operational costs to run the asset"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "community-use-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "zTcrYo",
+                            "type": "freeText",
+                            "title": "Who in the community currently uses the asset, or has used it in the past?",
+                            "answer": "<p>Test Community use/significance Form</p>"
+                        },
+                        {
+                            "key": "whlRYS",
+                            "type": "freeText",
+                            "title": "Tell us how losing the asset would affect, or has already affected, people in the community",
+                            "answer": "<p>Test Community use/significance Form</p>"
+                        },
+                        {
+                            "key": "NGSXHE",
+                            "type": "freeText",
+                            "title": "Why will the asset be lost without community intervention?",
+                            "answer": "<p>Test Community use/significance Form</p>"
+                        },
+                        {
+                            "key": "Ieudgn",
+                            "type": "freeText",
+                            "title": "Explain how the community will be better served with the asset under community ownership",
+                            "answer": "<p>Test Community use/significance Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "GMkooI",
+                    "question": "Who uses the asset"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "environmental-sustainability-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "dypuJs",
+                            "type": "freeText",
+                            "title": "Tell us how you have considered the environmental sustainability of your project",
+                            "answer": "<p>Test Environmental Sustainability Form</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "ljcxPd",
+                    "question": "How you've considered the environment"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "feasibility-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "iSbwDM",
+                            "type": "freeText",
+                            "title": "Tell us about the feasibility studies you have carried out for your project",
+                            "answer": "<p>Tell us about the feasibility studies you have carried out for your project</p>"
+                        },
+                        {
+                            "key": "jFPlEJ",
+                            "type": "list",
+                            "title": "Do you need to do any further feasibility work?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bBGnkL",
+                    "question": "Feasiblity studies you've carried out"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "WWdVTC",
+                            "type": "freeText",
+                            "title": "Describe the feasibility work you still need to complete",
+                            "answer": "<p>Describe the feasibility work you still need to complete</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "bBGnkL",
+                    "question": "Further feasibility work"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "declarations-cof",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "vSQKwD",
+                            "type": "list",
+                            "title": "Confirm you have considered subsidy control and state aid implications for your project, and the information you have given us is correct",
+                            "answer": false
+                        },
+                        {
+                            "key": "CQoLFp",
+                            "type": "list",
+                            "title": "Confirm youhave considered people with protected characteristics throughout the planning of your project",
+                            "answer": false
+                        },
+                        {
+                            "key": "jdPkiX",
+                            "type": "list",
+                            "title": "Confirm you have considered sustainability and the environment throughout the planning of your project, including compliance with the government's Net Zero ambitions",
+                            "answer": true
+                        },
+                        {
+                            "key": "qWuSCy",
+                            "type": "list",
+                            "title": "Confirm you have a bank account set up and associated with the organisation you are applying on behalf of",
+                            "answer": false
+                        },
+                        {
+                            "key": "tjZlml",
+                            "type": "list",
+                            "title": "Confirm that the information you've provided in this application is accurate to the best of your knowledge on the date of submission",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "LkvizC",
+                    "question": "Agree to the final confirmations"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        }
+    ],
+    "status": "SUBMITTED",
+    "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+    "language": "en",
+    "round_id": "27ab26c2-e58e-4bfe-917d-64be10d16496",
+    "reference": "COF-R4W2-UCOVJO",
+    "account_id": "1e8884e2-b043-427f-ba09-7ec2ca409ef0",
+    "round_name": "Round 4 Window 2",
+    "started_at": "2024-12-13T13:53:41.573539",
+    "last_edited": "2024-12-13T13:58:28.478011",
+    "project_name": "Community Ownership Fund E2E Journey Ortiz, Lakin and Gutkowski Project ",
+    "date_submitted": "2024-12-13T13:58:37.579455+00:00"
+}

--- a/tests/application_store_tests/test_routes.py
+++ b/tests/application_store_tests/test_routes.py
@@ -10,12 +10,10 @@ from fsd_utils.services.aws_extended_client import SQSExtendedClient
 from moto import mock_aws
 
 from application_store.db.models import Applications, ResearchSurvey
-from application_store.db.models.application.enums import Status
 from application_store.db.queries.application import get_all_applications
 from application_store.db.schemas import ApplicationSchema
 from application_store.external_services.models.fund import Fund
 from application_store.external_services.models.round import Round
-from assessment_store.db.models.assessment_record.assessment_records import AssessmentRecord
 from config import Config
 from db import db
 from tests.application_store_tests.helpers import (
@@ -632,56 +630,6 @@ def test_put_returns_400_on_submitted_application(flask_test_client, _db, seed_a
 
     assert response.status_code == 400
     assert b"Not allowed to edit a submitted application." in response.content
-
-
-@mock_aws
-@pytest.mark.apps_to_insert([test_application_data[0]])
-def test_successful_submitted_application(
-    flask_test_client,
-    mock_successful_submit_notification,
-    _db,
-    seed_application_records,
-    mocker,
-    mock_get_fund_data,
-    mock_get_round,
-):
-    """
-    GIVEN We have a functioning Application Store API
-    WHEN an application is submitted
-    THEN a 201 response is received in the correct format
-    """
-    with mock.patch(
-        "application_store.api.routes.application.routes.ApplicationsView._get_sqs_client"
-    ) as mock_get_sqs_client:
-        mock_get_sqs_client.return_value = _mock_aws_client()
-        mocker.patch("application_store.db.queries.application.queries.list_files_by_prefix", new=lambda _: [])
-
-        application_id = seed_application_records[0].id
-        # Update reference to a fund that has data mappings in assess
-        seed_application_records[0].reference = "CTDF-CR1-" + seed_application_records[0].reference.split("-")[2]
-
-        _db.session.add(seed_application_records[0])
-        _db.session.commit()
-
-        response = flask_test_client.post(
-            f"/application/applications/{application_id}/submit",
-            follow_redirects=True,
-        )
-
-        assert response.status_code == 201
-        assert all(k in response.json() for k in ("id", "email", "reference", "eoi_decision"))
-
-        _db.session.expunge(seed_application_records[0])
-        application_after_submit = _db.session.query(Applications).where(Applications.id == application_id).one()
-
-        assert application_after_submit.status == Status.SUBMITTED
-
-        assessment_record = (
-            _db.session.query(AssessmentRecord).where(AssessmentRecord.application_id == application_id).one()
-        )
-        assert assessment_record
-
-        # Make assessment insert surface the errors, work out how to 'transaction-ise' and then fix null project name
 
 
 @pytest.mark.apps_to_insert([test_application_data[0]])

--- a/tests/application_store_tests/test_submit.py
+++ b/tests/application_store_tests/test_submit.py
@@ -1,0 +1,124 @@
+import pytest
+
+from application_store.db.exceptions.submit import SubmitError
+from application_store.db.models.application.applications import Applications
+from application_store.db.models.application.enums import Language
+from application_store.db.models.application.enums import Status as ApplicationStatus
+from application_store.db.queries.application.queries import submit_application
+from application_store.external_services.exceptions import NotificationError
+from assessment_store.config.mappings.assessment_mapping_fund_round import CTDF_FUND_ID, CTDF_ROUND_1_ID
+from assessment_store.db.models.assessment_record.assessment_records import AssessmentRecord
+
+
+@pytest.mark.apps_to_insert(
+    [
+        {
+            "account_id": "usera",
+            "fund_id": CTDF_FUND_ID,
+            "round_id": CTDF_ROUND_1_ID,
+            "language": Language.en,
+        },
+    ]
+)
+def test_submit_route_success(
+    flask_test_client,
+    mock_successful_submit_notification,
+    _db,
+    seed_application_records,
+    mocker,
+    mock_get_fund_data,
+    mock_get_round,
+):
+    mocker.patch("application_store.db.queries.application.queries.list_files_by_prefix", new=lambda _: [])
+    target_application = seed_application_records[0]
+    application_id = target_application.id
+    # project_info_form = next(form for form in target_application.forms if form.name == "project-information")
+    # project_info_form.json = [
+    #     {
+    #         "category": "FabDefault",
+    #         "question": "Project name",
+    #         "fields": [{"key": "VcyKVN", "title": "Project name", "type": "text", "answer": "unit test"}],
+    #         "status": "COMPLETED",
+    #     },
+    # ]
+
+    # Update reference to a fund that has data mappings in assess
+    target_application.reference = "CTDF-CR1-" + seed_application_records[0].reference.split("-")[2]
+    target_application.project_name = "unit test project"
+
+    _db.session.add(target_application)
+    _db.session.commit()
+
+    response = flask_test_client.post(
+        f"/application/applications/{application_id}/submit",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 201
+    assert all(k in response.json() for k in ("id", "email", "reference", "eoi_decision"))
+
+    _db.session.expunge(target_application)
+    application_after_submit = _db.session.query(Applications).where(Applications.id == application_id).one()
+
+    assert application_after_submit.status == ApplicationStatus.SUBMITTED
+
+    assessment_record = (
+        _db.session.query(AssessmentRecord).where(AssessmentRecord.application_id == application_id).one()
+    )
+    assert assessment_record
+
+
+def test_submit_route_submit_error(
+    flask_test_client,
+    seed_application_records,
+    mocker,
+):
+    target_application = seed_application_records[0]
+    application_id = target_application.id
+    mocker.patch(
+        "application_store.api.routes.application.routes.submit_application",
+        side_effect=SubmitError(application_id=application_id),
+    )
+
+    response = flask_test_client.post(
+        f"/application/applications/{application_id}/submit",
+        follow_redirects=True,
+    )
+    assert response.status_code == 500
+    assert response.json()["message"] == f"Unable to submit application {application_id}"
+
+
+def test_submit_application_raises_error_on_db_violation(seed_application_records, mocker, _db):
+    mocker.patch("application_store.db.queries.application.queries.list_files_by_prefix", new=lambda _: [])
+    target_application = seed_application_records[0]
+    target_application.reference = "CTDF-CR1-" + seed_application_records[0].reference.split("-")[2]
+    target_application.project_name = None  # will cause not null constraint violation
+
+    _db.session.add(target_application)
+    _db.session.commit()
+    application_id = target_application.id
+    with pytest.raises(SubmitError) as se:
+        submit_application(application_id)
+        assert str(se) == f"Unable to submit application {application_id}"
+
+
+def test_submit_application_route_succeeds_on_notify_error(seed_application_records, mocker, _db, flask_test_client):
+    mocker.patch("application_store.db.queries.application.queries.list_files_by_prefix", new=lambda _: [])
+    target_application = seed_application_records[0]
+    application_id = target_application.id
+    target_application.reference = "CTDF-CR1-" + seed_application_records[0].reference.split("-")[2]
+    target_application.project_name = "unit test project"
+
+    _db.session.add(target_application)
+    _db.session.commit()
+
+    mocker.patch(
+        "application_store.api.routes.application.routes.send_submit_notification",
+        side_effect=NotificationError(),
+    )
+
+    response = flask_test_client.post(
+        f"/application/applications/{application_id}/submit",
+        follow_redirects=True,
+    )
+    assert response.status_code == 201

--- a/tests/application_store_tests/test_submit.py
+++ b/tests/application_store_tests/test_submit.py
@@ -1,11 +1,18 @@
+import json
+from uuid import uuid4
+
 import pytest
 
 from application_store.db.exceptions.submit import SubmitError
 from application_store.db.models.application.applications import Applications
 from application_store.db.models.application.enums import Status as ApplicationStatus
-from application_store.db.queries.application.queries import submit_application
+from application_store.db.queries.application.queries import create_application, submit_application
+from application_store.db.queries.form.queries import add_new_forms
+from application_store.db.queries.updating.queries import update_form
 from application_store.external_services.exceptions import NotificationError
+from assessment_store.config.mappings.assessment_mapping_fund_round import COF_ROUND_4_W2_ID
 from assessment_store.db.models.assessment_record.assessment_records import AssessmentRecord
+from tests.assessment_store_tests.test_assessment_mapping_fund_round import COF_FUND_ID
 
 
 @pytest.fixture(scope="function")
@@ -23,6 +30,96 @@ def mock_data_key_mappings(monkeypatch):
         fund_round_data_key_mappings,
     )
     yield
+
+
+def test_submit_application_with_location_bad_key(_db, app, clear_test_data, mocker, monkeypatch):
+    mocker.patch("application_store.db.queries.application.queries.list_files_by_prefix", new=lambda _: [])
+    fund_round_data_key_mappings = {
+        "TESTTEST": {
+            "location": "badkey",
+            "asset_type": None,
+            "funding_one": None,
+            "funding_two": None,
+        }
+    }
+    monkeypatch.setattr(
+        "assessment_store.db.queries.assessment_records._helpers.fund_round_data_key_mappings",
+        fund_round_data_key_mappings,
+    )
+    with open("tests/application_store_tests/seed_data/COF_R4W2_all_forms.json", "r") as f:
+        cof_application = json.load(f)
+        forms = cof_application["forms"]
+    empty_forms = [form["name"] for form in forms]
+    target_application = create_application(
+        account_id=uuid4(), fund_id=COF_FUND_ID, round_id=COF_ROUND_4_W2_ID, language="en"
+    )
+    target_application.project_name = "test"
+    application_id = target_application.id
+    add_new_forms(forms=empty_forms, application_id=application_id)
+
+    for form in forms:
+        update_form(
+            application_id,
+            form["name"],
+            form["questions"],
+            True,
+        )
+
+    submit_application(application_id)
+
+    assessment_record: AssessmentRecord = (
+        _db.session.query(AssessmentRecord).where(AssessmentRecord.application_id == application_id).one()
+    )
+    assert assessment_record
+    assert assessment_record.location_json_blob
+    assert assessment_record.location_json_blob["error"] is True
+
+
+def test_submit_application_with_location(_db, app, clear_test_data, mocker, monkeypatch):
+    mocker.patch("application_store.db.queries.application.queries.list_files_by_prefix", new=lambda _: [])
+    fund_round_data_key_mappings = {
+        "TESTTEST": {
+            "location": "EfdliG",
+            "asset_type": None,
+            "funding_one": None,
+            "funding_two": None,
+        }
+    }
+    monkeypatch.setattr(
+        "assessment_store.db.queries.assessment_records._helpers.fund_round_data_key_mappings",
+        fund_round_data_key_mappings,
+    )
+    with open("tests/application_store_tests/seed_data/COF_R4W2_all_forms.json", "r") as f:
+        cof_application = json.load(f)
+        forms = cof_application["forms"]
+    # target_application = create_app_with_blank_forms(
+    #     {"account_id": uuid4(), "fund_id": COF_FUND_ID, "round_id": COF_ROUND_4_W2_ID, "language": "en"}
+    # )
+    empty_forms = [form["name"] for form in forms]
+    target_application = create_application(
+        account_id=uuid4(), fund_id=COF_FUND_ID, round_id=COF_ROUND_4_W2_ID, language="en"
+    )
+    target_application.project_name = "test"
+    application_id = target_application.id
+    add_new_forms(forms=empty_forms, application_id=application_id)
+
+    for form in forms:
+        update_form(
+            application_id,
+            form["name"],
+            form["questions"],
+            True,
+        )
+
+    submit_application(application_id)
+
+    assessment_record: AssessmentRecord = (
+        _db.session.query(AssessmentRecord).where(AssessmentRecord.application_id == application_id).one()
+    )
+    assert assessment_record
+    assert assessment_record.location_json_blob
+    assert assessment_record.location_json_blob["error"] is False
+    assert assessment_record.location_json_blob["county"] == "Hampshire"
 
 
 def test_submit_route_success(

--- a/tests/application_store_tests/test_submit.py
+++ b/tests/application_store_tests/test_submit.py
@@ -56,10 +56,11 @@ def test_submit_route_success(
 
     assert application_after_submit.status == ApplicationStatus.SUBMITTED
 
-    assessment_record = (
+    assessment_record: AssessmentRecord = (
         _db.session.query(AssessmentRecord).where(AssessmentRecord.application_id == application_id).one()
     )
     assert assessment_record
+    assert assessment_record.jsonb_blob["forms"]
 
 
 def test_submit_route_submit_error(

--- a/tests/application_store_tests/test_submit.py
+++ b/tests/application_store_tests/test_submit.py
@@ -93,7 +93,8 @@ def test_submit_application_raises_error_on_db_violation(seed_application_record
     application_id = target_application.id
     with pytest.raises(SubmitError) as se:
         submit_application(application_id)
-        assert str(se) == f"Unable to submit application {application_id}"
+    assert type(se.value) is SubmitError
+    assert str(se.value).startswith(f"Unable to submit application [{application_id}]")
 
 
 def test_submit_application_route_succeeds_on_notify_error(

--- a/tests/assessment_store_tests/conftest.py
+++ b/tests/assessment_store_tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import random
 from uuid import uuid4
@@ -7,7 +8,9 @@ import pytest
 from app import create_app
 from assessment_store.db.models import AssessmentRound
 from assessment_store.db.models.assessment_record import AssessmentRecord
-from assessment_store.db.models.assessment_record.allocation_association import AllocationAssociation
+from assessment_store.db.models.assessment_record.allocation_association import (
+    AllocationAssociation,
+)
 from assessment_store.db.models.assessment_record.tag_association import TagAssociation
 from assessment_store.db.models.comment import Comment, CommentsUpdate
 from assessment_store.db.models.flags.assessment_flag import AssessmentFlag
@@ -16,13 +19,23 @@ from assessment_store.db.models.qa_complete import QaComplete
 from assessment_store.db.models.score import Score
 from assessment_store.db.models.tag.tag_types import TagType
 from assessment_store.db.queries import bulk_insert_application_record
-from assessment_store.db.queries.scores.queries import _insert_scoring_system, insert_scoring_system_for_round_id
+from assessment_store.db.queries.scores.queries import (
+    _insert_scoring_system,
+    insert_scoring_system_for_round_id,
+)
 from assessment_store.db.queries.tags.queries import insert_tags
 from assessment_store.db.schemas.schemas import TagSchema, TagTypeSchema
 from tests.assessment_store_tests._sql_infos import attach_listeners
 
 with open("tests/assessment_store_tests/test_data/hand-crafted-apps.json", "r") as f:
     test_input_data = json.load(f)
+with open("tests/assessment_store_tests/test_data/ctdf-application.json", "r") as f:
+    ctdf_input_data = json.load(f)
+
+
+@pytest.fixture
+def ctdf_application():
+    yield copy.deepcopy(ctdf_input_data)
 
 
 @pytest.fixture(scope="function")

--- a/tests/assessment_store_tests/test_cof_import_mapper.py
+++ b/tests/assessment_store_tests/test_cof_import_mapper.py
@@ -2,7 +2,10 @@ import json
 
 import pytest
 
-from assessment_store.db.queries.assessment_records._helpers import derive_application_values
+from assessment_store.db.queries.assessment_records._helpers import (
+    derive_application_values,
+    get_location_json_from_postcode,
+)
 
 
 @pytest.fixture(scope="function")
@@ -22,21 +25,21 @@ def mock_data_key_mappings(monkeypatch):
     yield
 
 
-def test_derive_cof_values_no_location(mock_data_key_mappings):
+def test_derive_cof_values_no_location(app, mock_data_key_mappings):
     single_application_json = "tests/assessment_store_tests/test_data/single_application_no_location.json"
 
     with open(single_application_json, "r") as f:
         loaded_test_json = json.load(f)
     derived_fields = derive_application_values(loaded_test_json)
-    assert "TEST-REF" == derived_fields["short_id"], "Wrong Short ID"
-    assert "funding-service-design" == derived_fields["fund_id"], "Wrong Fund ID"
-    assert "summer" == derived_fields["round_id"], "Wrong Round ID"
-    assert "test-application-id" == derived_fields["application_id"], "Wrong Application ID"
-    assert "Project name" == derived_fields["project_name"], "Wrong Project Name"
-    assert "community-centre" == derived_fields["asset_type"], "Wrong Asset Type"
+    assert "TEST-REF" == derived_fields["short_id"]
+    assert "funding-service-design" == derived_fields["fund_id"]
+    assert "summer" == derived_fields["round_id"]
+    assert "test-application-id" == derived_fields["application_id"]
+    assert "Project name" == derived_fields["project_name"]
+    assert "community-centre" == derived_fields["asset_type"]
 
-    assert derived_fields["location_json_blob"]["error"] is True, "wrong error value"
-    assert "Not Available" == derived_fields["location_json_blob"]["county"], "wrong county value"
+    assert derived_fields["location_json_blob"]["error"] is True
+    assert "Not Available" == derived_fields["location_json_blob"]["county"]
 
 
 @pytest.mark.parametrize(
@@ -46,7 +49,7 @@ def test_derive_cof_values_no_location(mock_data_key_mappings):
         ("EX22 6TA", "England"),
     ],
 )
-def test_derive_cof_values_location_present_no_error(postcode, expected_country, mock_data_key_mappings):
+def test_derive_cof_values_location_present_no_error(app, postcode, expected_country, mock_data_key_mappings):
     single_application_json = "tests/assessment_store_tests/test_data/single_application_no_location.json"
 
     with open(single_application_json, "r") as f:
@@ -57,20 +60,65 @@ def test_derive_cof_values_location_present_no_error(postcode, expected_country,
         )
 
     derived_fields = derive_application_values(loaded_test_json)
-    assert "TEST-REF" == derived_fields["short_id"], "Wrong Short ID"
+    assert "TEST-REF" == derived_fields["short_id"]
 
-    assert derived_fields["location_json_blob"]["error"] is False, "wrong error value"
-    assert expected_country == derived_fields["location_json_blob"]["country"], "wrong county value"
+    assert derived_fields["location_json_blob"]["error"] is False
+    assert expected_country == derived_fields["location_json_blob"]["country"]
 
 
-def test_derive_cof_values_location_present_with_error(mock_data_key_mappings):
+def test_derive_cof_values_location_present_with_error(app, mock_data_key_mappings):
     single_application_json = "tests/assessment_store_tests/test_data/single_application_no_location.json"
 
     with open(single_application_json, "r") as f:
         loaded_test_json = json.load(f)
-    loaded_test_json["location_json_blob"] = {"error": True, "county": "error"}
     derived_fields = derive_application_values(loaded_test_json)
-    assert "TEST-REF" == derived_fields["short_id"], "Wrong Short ID"
+    assert "TEST-REF" == derived_fields["short_id"]
 
-    assert derived_fields["location_json_blob"]["error"] is True, "wrong error value"
-    assert "Not Available" == derived_fields["location_json_blob"]["county"], "wrong county value"
+    assert derived_fields["location_json_blob"]["error"] is True
+    assert "Not Available" == derived_fields["location_json_blob"]["county"]
+
+
+@pytest.mark.parametrize(
+    "field_one, field_two,funding_field_type, exp_total",
+    [
+        ("JzWvhj", "jLIgoi", None, 4700),
+        (None, "jLIgoi", None, 2400),
+        ("JzWvhj", None, None, 2300),
+        (None, None, None, 0),
+        ("both", "wrong", None, 0),
+        ("bad", "jLIgoi", None, 2400),
+        ("JzWvhj", "wrong", None, 2300),
+        (["JzWvhj"], ["jLIgoi"], "multiInputField", 4700),
+        (["JzWvhj"], [None], "multiInputField", 2300),
+        (["JzWvhj"], ["incorrect"], "multiInputField", 2300),
+        ([None], ["jLIgoi"], "multiInputField", 2400),
+        (["baad"], ["jLIgoi"], "multiInputField", 2400),
+        (["both lists"], ["are wrong"], "multiInputField", 0),
+    ],
+)
+def test_derive_funding(app, exp_total, field_one, field_two, funding_field_type, monkeypatch):
+    fund_round_data_key_mappings = {
+        "TESTREF": {
+            "location": None,
+            "asset_type": None,
+            "funding_one": field_one,
+            "funding_two": field_two,
+            "funding_field_type": funding_field_type,
+        }
+    }
+    monkeypatch.setattr(
+        "assessment_store.db.queries.assessment_records._helpers.fund_round_data_key_mappings",
+        fund_round_data_key_mappings,
+    )
+    single_application_json = "tests/assessment_store_tests/test_data/single_application_no_location.json"
+    with open(single_application_json, "r") as f:
+        loaded_test_json = json.load(f)
+    derived_fields = derive_application_values(loaded_test_json)
+    assert "TEST-REF" == derived_fields["short_id"]
+    assert derived_fields["funding_amount_requested"] == exp_total
+
+
+def test_get_location_request_error(app, mocker):
+    mocker.patch("assessment_store.db.queries.assessment_records._helpers.requests.post", side_effect=Exception())
+    location_data = get_location_json_from_postcode("AA12 1DB")
+    assert location_data is None

--- a/tests/assessment_store_tests/test_data/ctdf-application.json
+++ b/tests/assessment_store_tests/test_data/ctdf-application.json
@@ -1,0 +1,99 @@
+{
+    "id": null,
+    "forms": [
+        {
+            "name": "project-name-sample",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "VcyKVN",
+                            "type": "text",
+                            "title": "Project name",
+                            "answer": "Project e2e z9LdJ3aWbJA"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "FabDefault",
+                    "question": "Project name"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "KJtdhs",
+                            "type": "freeText",
+                            "title": "Project overview",
+                            "answer": "<p>project overview z9LdJ3aWbJA</p>"
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "FabDefault",
+                    "question": "Project overview"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        },
+        {
+            "name": "organisation-name-sample",
+            "status": "COMPLETED",
+            "questions": [
+                {
+                    "fields": [
+                        {
+                            "key": "yptqZX",
+                            "type": "text",
+                            "title": "Organisation name",
+                            "answer": "Organisation z9LdJ3aWbJA"
+                        },
+                        {
+                            "key": "BIxPht",
+                            "type": "list",
+                            "title": "Does your organisation use any  other names?",
+                            "answer": false
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": "FabDefault",
+                    "question": "Organisation name"
+                },
+                {
+                    "fields": [
+                        {
+                            "key": "markAsComplete",
+                            "type": "boolean",
+                            "title": "Do you want to mark this section as complete?",
+                            "answer": true
+                        }
+                    ],
+                    "status": "COMPLETED",
+                    "category": null,
+                    "question": "MarkAsComplete"
+                }
+            ]
+        }
+    ],
+    "status": "SUBMITTED",
+    "fund_id": "3dcfa617-cff8-4c2c-9edd-9568aa367d13",
+    "language": "en",
+    "round_id": "7ecd7d64-1854-44ab-a10c-a7af4b8d68e1",
+    "reference": "CTDF-CR1-ZLICOO",
+    "account_id": "c8c855c4-540c-48a8-8406-f66b7f686e7e",
+    "round_name": "Crash Round 1",
+    "started_at": "2024-12-09T10:56:46.444087",
+    "last_edited": "2024-12-09T10:56:48.370610",
+    "project_name": "Project e2e z9LdJ3aWbJA",
+    "date_submitted": "2024-12-09T10:56:48.695896"
+}

--- a/tests/assessment_store_tests/test_data/single_application_no_location.json
+++ b/tests/assessment_store_tests/test_data/single_application_no_location.json
@@ -876,7 +876,7 @@
                 "type": "text"
               },
               {
-                "answer": "2300",
+                "answer": "2400",
                 "key": "jLIgoi",
                 "title": "Revenue funding (optional)",
                 "type": "text"

--- a/tests/assessment_store_tests/test_import_applications.py
+++ b/tests/assessment_store_tests/test_import_applications.py
@@ -12,9 +12,7 @@ from assessment_store.config.mappings.assessment_mapping_fund_round import (
 from assessment_store.db.models.assessment_record.assessment_records import (
     AssessmentRecord,
 )
-from assessment_store.db.queries.assessment_records.queries import (
-    insert_application_record,
-)
+from assessment_store.db.queries.assessment_records.queries import bulk_insert_application_record
 from assessment_store.scripts.import_from_application import main
 from tests.assessment_store_tests._helpers import row_data
 
@@ -153,8 +151,8 @@ def test_insert_application_record(
         },
     )
 
-    result = insert_application_record(
-        application_json_string=ctdf_application,
+    result = bulk_insert_application_record(
+        application_json_strings=[ctdf_application],
         application_type=application_type,
         is_json=is_json,
     )
@@ -195,8 +193,8 @@ def test_insert_application_record_duplicate(mocker, seed_application_records, _
         return_value=derived_values,
     )
 
-    result = insert_application_record(
-        application_json_string=ctdf_application,
+    result = bulk_insert_application_record(
+        application_json_strings=[ctdf_application],
         application_type=None,
         is_json=True,
     )
@@ -218,8 +216,8 @@ def test_insert_application_record_duplicate(mocker, seed_application_records, _
         return_value=derived_values,
     )
 
-    result2 = insert_application_record(
-        application_json_string=ctdf_application,
+    result2 = bulk_insert_application_record(
+        application_json_strings=[ctdf_application],
         application_type=None,
         is_json=True,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -326,30 +326,6 @@ uvicorn = [
 ]
 
 [[package]]
-name = "coverage"
-version = "7.6.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5b/d2/c25011f4d036cf7e8acbbee07a8e09e9018390aee25ba085596c4b83d510/coverage-7.6.9.tar.gz", hash = "sha256:4a8d8977b0c6ef5aeadcb644da9e69ae0dcfe66ec7f368c89c72e058bd71164d", size = 801710 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/f3/f830fb53bf7e4f1d5542756f61d9b740352a188f43854aab9409c8cdeb18/coverage-7.6.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:85d9636f72e8991a1706b2b55b06c27545448baf9f6dbf51c4004609aacd7dcb", size = 207024 },
-    { url = "https://files.pythonhosted.org/packages/4e/e3/ea5632a3a6efd00ab0a791adc0f3e48512097a757ee7dcbee5505f57bafa/coverage-7.6.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:608a7fd78c67bee8936378299a6cb9f5149bb80238c7a566fc3e6717a4e68710", size = 207463 },
-    { url = "https://files.pythonhosted.org/packages/e4/ae/18ff8b5580e27e62ebcc888082aa47694c2772782ea7011ddf58e377e98f/coverage-7.6.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96d636c77af18b5cb664ddf12dab9b15a0cfe9c0bde715da38698c8cea748bfa", size = 235902 },
-    { url = "https://files.pythonhosted.org/packages/6a/52/57030a8d15ab935624d298360f0a6704885578e39f7b4f68569e59f5902d/coverage-7.6.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75cded8a3cff93da9edc31446872d2997e327921d8eed86641efafd350e1df1", size = 233806 },
-    { url = "https://files.pythonhosted.org/packages/d0/c5/4466602195ecaced298d55af1e29abceb812addabefd5bd9116a204f7bab/coverage-7.6.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7b15f589593110ae767ce997775d645b47e5cbbf54fd322f8ebea6277466cec", size = 234966 },
-    { url = "https://files.pythonhosted.org/packages/b0/1c/55552c3009b7bf96732e36548596ade771c87f89cf1f5a8e3975b33539b5/coverage-7.6.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:44349150f6811b44b25574839b39ae35291f6496eb795b7366fef3bd3cf112d3", size = 234029 },
-    { url = "https://files.pythonhosted.org/packages/bb/7d/da3dca6878701182ea42c51df47a47c80eaef2a76f5aa3e891dc2a8cce3f/coverage-7.6.9-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d891c136b5b310d0e702e186d70cd16d1119ea8927347045124cb286b29297e5", size = 232494 },
-    { url = "https://files.pythonhosted.org/packages/28/cc/39de85ac1d5652bc34ff2bee39ae251b1fdcaae53fab4b44cab75a432bc0/coverage-7.6.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:db1dab894cc139f67822a92910466531de5ea6034ddfd2b11c0d4c6257168073", size = 233611 },
-    { url = "https://files.pythonhosted.org/packages/d1/2b/7eb011a9378911088708f121825a71134d0c15fac96972a0ae7a8f5a4049/coverage-7.6.9-cp310-cp310-win32.whl", hash = "sha256:41ff7b0da5af71a51b53f501a3bac65fb0ec311ebed1632e58fc6107f03b9198", size = 209712 },
-    { url = "https://files.pythonhosted.org/packages/5b/35/c3f40a2269b416db34ce1dedf682a7132c26f857e33596830fa4deebabf9/coverage-7.6.9-cp310-cp310-win_amd64.whl", hash = "sha256:35371f8438028fdccfaf3570b31d98e8d9eda8bb1d6ab9473f5a390969e98717", size = 210553 },
-    { url = "https://files.pythonhosted.org/packages/15/0e/4ac9035ee2ee08d2b703fdad2d84283ec0bad3b46eb4ad6affb150174cb6/coverage-7.6.9-pp39.pp310-none-any.whl", hash = "sha256:f3ca78518bc6bc92828cd11867b121891d75cae4ea9e908d72030609b996db1b", size = 199270 },
-]
-
-[package.optional-dependencies]
-toml = [
-    { name = "tomli" },
-]
-
-[[package]]
 name = "cryptography"
 version = "43.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -667,7 +643,6 @@ dev = [
     { name = "moto", extra = ["s3"] },
     { name = "pre-commit" },
     { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-flask" },
     { name = "pytest-html" },

--- a/uv.lock
+++ b/uv.lock
@@ -326,6 +326,30 @@ uvicorn = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.6.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/d2/c25011f4d036cf7e8acbbee07a8e09e9018390aee25ba085596c4b83d510/coverage-7.6.9.tar.gz", hash = "sha256:4a8d8977b0c6ef5aeadcb644da9e69ae0dcfe66ec7f368c89c72e058bd71164d", size = 801710 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/f3/f830fb53bf7e4f1d5542756f61d9b740352a188f43854aab9409c8cdeb18/coverage-7.6.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:85d9636f72e8991a1706b2b55b06c27545448baf9f6dbf51c4004609aacd7dcb", size = 207024 },
+    { url = "https://files.pythonhosted.org/packages/4e/e3/ea5632a3a6efd00ab0a791adc0f3e48512097a757ee7dcbee5505f57bafa/coverage-7.6.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:608a7fd78c67bee8936378299a6cb9f5149bb80238c7a566fc3e6717a4e68710", size = 207463 },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/18ff8b5580e27e62ebcc888082aa47694c2772782ea7011ddf58e377e98f/coverage-7.6.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96d636c77af18b5cb664ddf12dab9b15a0cfe9c0bde715da38698c8cea748bfa", size = 235902 },
+    { url = "https://files.pythonhosted.org/packages/6a/52/57030a8d15ab935624d298360f0a6704885578e39f7b4f68569e59f5902d/coverage-7.6.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75cded8a3cff93da9edc31446872d2997e327921d8eed86641efafd350e1df1", size = 233806 },
+    { url = "https://files.pythonhosted.org/packages/d0/c5/4466602195ecaced298d55af1e29abceb812addabefd5bd9116a204f7bab/coverage-7.6.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7b15f589593110ae767ce997775d645b47e5cbbf54fd322f8ebea6277466cec", size = 234966 },
+    { url = "https://files.pythonhosted.org/packages/b0/1c/55552c3009b7bf96732e36548596ade771c87f89cf1f5a8e3975b33539b5/coverage-7.6.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:44349150f6811b44b25574839b39ae35291f6496eb795b7366fef3bd3cf112d3", size = 234029 },
+    { url = "https://files.pythonhosted.org/packages/bb/7d/da3dca6878701182ea42c51df47a47c80eaef2a76f5aa3e891dc2a8cce3f/coverage-7.6.9-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d891c136b5b310d0e702e186d70cd16d1119ea8927347045124cb286b29297e5", size = 232494 },
+    { url = "https://files.pythonhosted.org/packages/28/cc/39de85ac1d5652bc34ff2bee39ae251b1fdcaae53fab4b44cab75a432bc0/coverage-7.6.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:db1dab894cc139f67822a92910466531de5ea6034ddfd2b11c0d4c6257168073", size = 233611 },
+    { url = "https://files.pythonhosted.org/packages/d1/2b/7eb011a9378911088708f121825a71134d0c15fac96972a0ae7a8f5a4049/coverage-7.6.9-cp310-cp310-win32.whl", hash = "sha256:41ff7b0da5af71a51b53f501a3bac65fb0ec311ebed1632e58fc6107f03b9198", size = 209712 },
+    { url = "https://files.pythonhosted.org/packages/5b/35/c3f40a2269b416db34ce1dedf682a7132c26f857e33596830fa4deebabf9/coverage-7.6.9-cp310-cp310-win_amd64.whl", hash = "sha256:35371f8438028fdccfaf3570b31d98e8d9eda8bb1d6ab9473f5a390969e98717", size = 210553 },
+    { url = "https://files.pythonhosted.org/packages/15/0e/4ac9035ee2ee08d2b703fdad2d84283ec0bad3b46eb4ad6affb150174cb6/coverage-7.6.9-pp39.pp310-none-any.whl", hash = "sha256:f3ca78518bc6bc92828cd11867b121891d75cae4ea9e908d72030609b996db1b", size = 199270 },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli" },
+]
+
+[[package]]
 name = "cryptography"
 version = "43.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -643,6 +667,7 @@ dev = [
     { name = "moto", extra = ["s3"] },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-flask" },
     { name = "pytest-html" },
@@ -1361,6 +1386,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
 ]
+
 
 [[package]]
 name = "pytest-env"


### PR DESCRIPTION
### Change description
https://mhclgdigital.atlassian.net/browse/FSPT-177
This PR stops application-store from writing to the import queue for assessment. Instead, it calls assessment-store directly to copy the data into the assessment tables. Covered in this PR:
- Updated `submit_application` to call assessment store functions directly to derive application values and insert the row.
- Moved the `send_submit_notification` code into a separate function for easier readability
- Unit tests for the new submit route and functions
- Updated error handling code so that:
    - Submit will not fail for the user if the notification fails to send, or if we can't derive application values

Out of scope:
- Removing the code to read from the queue in assessment. This de-risks the change when it goes into prod and means no data will be lost if someone submits using the old method as we deploy the change.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Pull this branch.
Create and submit an application
You should see it in assessment as normal.
No changes should be visible to the user


### Screenshots of UI changes (if applicable)
N/A