### PR TITLE
adding script for errors in deriving values

### DIFF
--- a/assessment_store/db/queries/assessment_records/_helpers.py
+++ b/assessment_store/db/queries/assessment_records/_helpers.py
@@ -124,8 +124,8 @@ def derive_application_values(application_json):  # noqa: C901 - historical sadn
         # Don't throw an exception here as we want to soft-fail - ie the submission process still works, but devs are
         # alerted to the lack of mappings
         current_app.logger.error(
-            "No assessment data mappings for fund round [fund_round_shortname]. "
-            "Cannot derive values for application [application_id]",
+            "No assessment data mappings for fund round {fund_round_shortname}. "
+            "Cannot derive values for application {application_id}",
             extra=dict(fund_round_shortname=fund_round_shortname, application_id=application_id),
         )
         return derived_values

--- a/assessment_store/scripts/derive_assessment_values.py
+++ b/assessment_store/scripts/derive_assessment_values.py
@@ -1,0 +1,53 @@
+import click
+
+from application_store.db.queries.application.queries import get_application
+from assessment_store.db.models.assessment_record.assessment_records import AssessmentRecord
+from assessment_store.db.queries.assessment_records._helpers import derive_application_values
+
+
+@click.command()
+@click.option(
+    "-a",
+    "--application_id",
+    help="Application ID to derive values",
+    prompt=True,
+)
+# @click.option(
+#     "-c",
+#     "--commit",
+#     is_flag=True,
+#     default=False,
+#     show_default=True,
+#     help="Whether to commit the derived values to assessment_store",
+#     prompt=False,
+# )
+def derive_assessment_values(application_id):
+    from flask import current_app
+
+    from db import db
+
+    current_app.logger.info(
+        "Deriving values for {application_id}",
+        extra=dict(application_id=application_id),
+    )
+
+    application_json = get_application(application_id, include_forms=True, as_json=True)
+    derived_values = derive_application_values(application_json)
+    current_app.logger.info("Derived the following values {derived_values}", extra=dict(derived_values=derived_values))
+
+    if click.confirm("Do you want to commit those values to the database?"):
+        assessment_record: AssessmentRecord = db.session.get(AssessmentRecord, application_id)
+        assessment_record.location_json_blob = derived_values["location_json_blob"]
+        assessment_record.funding_amount_requested = derived_values["funding_amount_requested"]
+        assessment_record.asset_type = derived_values["asset_type"]
+        db.session.commit()
+        current_app.logger.info("Database updated with derived values")
+    else:
+        current_app.logger.info("Database not updated")
+
+
+if __name__ == "__main__":
+    from app import app
+
+    with app.app.app_context():
+        derive_assessment_values()

--- a/assessment_store/scripts/derive_assessment_values.py
+++ b/assessment_store/scripts/derive_assessment_values.py
@@ -1,3 +1,5 @@
+import json
+
 import click
 
 from application_store.db.queries.application.queries import get_application
@@ -12,15 +14,6 @@ from assessment_store.db.queries.assessment_records._helpers import derive_appli
     help="Application ID to derive values",
     prompt=True,
 )
-# @click.option(
-#     "-c",
-#     "--commit",
-#     is_flag=True,
-#     default=False,
-#     show_default=True,
-#     help="Whether to commit the derived values to assessment_store",
-#     prompt=False,
-# )
 def derive_assessment_values(application_id):
     from flask import current_app
 
@@ -33,7 +26,8 @@ def derive_assessment_values(application_id):
 
     application_json = get_application(application_id, include_forms=True, as_json=True)
     derived_values = derive_application_values(application_json)
-    current_app.logger.info("Derived the following values {derived_values}", extra=dict(derived_values=derived_values))
+
+    print(json.dumps(derived_values, sort_keys=True, indent=2))
 
     if click.confirm("Do you want to commit those values to the database?"):
         assessment_record: AssessmentRecord = db.session.get(AssessmentRecord, application_id)

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -15,3 +15,16 @@ class DevelopmentConfig(Config):
 
     # Logging
     FSD_LOG_LEVEL = logging.INFO
+    # ---------------
+    # AWS Config
+    # ---------------
+    AWS_SECRET_ACCESS_KEY = AWS_SQS_SECRET_ACCESS_KEY = "test_secret_key"  # pragma: allowlist secret
+    AWS_ACCESS_KEY_ID = AWS_SQS_ACCESS_KEY_ID = "test_access_key"  # pragma: allowlist secret
+    AWS_SQS_IMPORT_APP_PRIMARY_QUEUE_URL = "fsd-queue-test"
+    AWS_SQS_IMPORT_APP_SECONDARY_QUEUE_URL = "test_secondary_url"
+    AWS_SQS_REGION = AWS_REGION = "eu-west-2"
+
+    # ---------------
+    # S3 Config
+    # ---------------
+    AWS_MSG_BUCKET_NAME = "fsd-notification-bucket"


### PR DESCRIPTION
### Change description
Now that we insert into assessment_store when a user submits an application, the `derive_values` call can fail. The user is not blocked but we write any such errors to Sentry.

This PR adds a script to manually run `derive_values` for a specific application, and then optionally commit those changes to the DB.

Run book for when and how to use this script: https://mhclgdigital.atlassian.net/wiki/spaces/FS/pages/81068033/Pre-Award+Common+Support+Tasks#Re-run-derive_values-for-an-application-in-assessment_store

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Idenitfy an application that exists in `assessment_records`
- Update that application to have some arbitrary value in any of `funding_amount_requested`, `asset_type` or `location_json_blob`
- Run the script with `python -m assessment_store.scripts.derive_assessment_values -a <application_id>`
- After confirmation, you should see that row updated with correct values for the fields above

