### PR TITLE
FSPT-179 Add host matching

### DIFF
--- a/account_store/core/account.py
+++ b/account_store/core/account.py
@@ -6,13 +6,14 @@ from typing import Dict, Tuple
 
 import sqlalchemy
 from email_validator import validate_email
-from flask import Blueprint, abort, request
+from flask import abort, request
 from sqlalchemy import any_, delete, or_, select
 from sqlalchemy.orm import selectinload
 
 from account_store.db.models.account import Account
 from account_store.db.models.role import Role
 from account_store.db.schemas.account import AccountSchema
+from common.blueprints import Blueprint
 from db import db
 
 account_core_bp = Blueprint("account_core_bp", __name__)

--- a/app.py
+++ b/app.py
@@ -55,12 +55,12 @@ def create_app() -> Flask:
     init_sentry()
 
     # TODO: See above
-    flask_app = ConnexionCompatibleJSONFlask(__name__)
+    flask_app = ConnexionCompatibleJSONFlask(__name__, host_matching=True, static_host="<host_from_current_request>")
 
-    flask_app.register_blueprint(account_core_bp, url_prefix="/account")
-    flask_app.register_blueprint(fund_store_bp, url_prefix="/fund")
-    flask_app.register_blueprint(application_store_bp, url_prefix="/application")
-    flask_app.register_blueprint(assessment_store_bp, url_prefix="/assessment")
+    flask_app.register_blueprint(account_core_bp, url_prefix="/account", host=Config.API_HOST)
+    flask_app.register_blueprint(fund_store_bp, url_prefix="/fund", host=Config.API_HOST)
+    flask_app.register_blueprint(application_store_bp, url_prefix="/application", host=Config.API_HOST)
+    flask_app.register_blueprint(assessment_store_bp, url_prefix="/assessment", host=Config.API_HOST)
 
     flask_app.config.from_object("config.Config")
 

--- a/application_store/api/routes/application/routes.py
+++ b/application_store/api/routes/application/routes.py
@@ -1,7 +1,7 @@
 import time
 from distutils.util import strtobool
 
-from flask import Blueprint, current_app, jsonify, request, send_file
+from flask import current_app, jsonify, request, send_file
 from flask.views import MethodView
 from fsd_utils import evaluate_response
 from sqlalchemy.orm.exc import NoResultFound
@@ -52,6 +52,7 @@ from application_store.external_services import (
 from application_store.external_services.exceptions import (
     NotificationError,
 )
+from common.blueprints import Blueprint
 
 application_store_bp = Blueprint("application_store_bp", __name__)
 

--- a/assessment_store/api/routes/__init__.py
+++ b/assessment_store/api/routes/__init__.py
@@ -1,4 +1,5 @@
-from flask import Blueprint
+from common.blueprints import Blueprint
+from config import Config
 
 from .assessment_routes import assessment_assessment_bp
 from .comment_routes import assessment_comment_bp
@@ -10,11 +11,11 @@ from .tag_routes import assessment_tag_bp
 from .user_routes import assessment_user_bp
 
 assessment_store_bp = Blueprint("assessment_store_bp", __name__)
-assessment_store_bp.register_blueprint(assessment_comment_bp)
-assessment_store_bp.register_blueprint(assessment_flag_bp)
-assessment_store_bp.register_blueprint(assessment_progress_bp)
-assessment_store_bp.register_blueprint(assessment_qa_bp)
-assessment_store_bp.register_blueprint(assessment_score_bp)
-assessment_store_bp.register_blueprint(assessment_tag_bp)
-assessment_store_bp.register_blueprint(assessment_user_bp)
-assessment_store_bp.register_blueprint(assessment_assessment_bp)
+assessment_store_bp.register_blueprint(assessment_comment_bp, host=Config.API_HOST)
+assessment_store_bp.register_blueprint(assessment_flag_bp, host=Config.API_HOST)
+assessment_store_bp.register_blueprint(assessment_progress_bp, host=Config.API_HOST)
+assessment_store_bp.register_blueprint(assessment_qa_bp, host=Config.API_HOST)
+assessment_store_bp.register_blueprint(assessment_score_bp, host=Config.API_HOST)
+assessment_store_bp.register_blueprint(assessment_tag_bp, host=Config.API_HOST)
+assessment_store_bp.register_blueprint(assessment_user_bp, host=Config.API_HOST)
+assessment_store_bp.register_blueprint(assessment_assessment_bp, host=Config.API_HOST)

--- a/assessment_store/api/routes/assessment_routes.py
+++ b/assessment_store/api/routes/assessment_routes.py
@@ -1,7 +1,7 @@
 import copy
 from typing import Dict, List
 
-from flask import Blueprint, Response, current_app, request
+from flask import Response, current_app, request
 
 from assessment_store.api.models.sub_criteria import SubCriteria
 from assessment_store.api.routes._helpers import compress_response, transform_to_assessor_task_list_metadata
@@ -30,6 +30,7 @@ from assessment_store.db.queries.scores.queries import (
     get_scoring_system_for_round_id,
     get_sub_criteria_to_latest_score_map,
 )
+from common.blueprints import Blueprint
 from config import Config
 
 assessment_assessment_bp = Blueprint("assessment_assessment_bp", __name__)

--- a/assessment_store/api/routes/comment_routes.py
+++ b/assessment_store/api/routes/comment_routes.py
@@ -1,8 +1,9 @@
 from typing import Dict
 
-from flask import Blueprint, request
+from flask import request
 
 from assessment_store.db.queries.comments import create_comment, get_comments_from_db, update_comment
+from common.blueprints import Blueprint
 
 assessment_comment_bp = Blueprint("assessment_comment_bp", __name__)
 

--- a/assessment_store/api/routes/flag_routes.py
+++ b/assessment_store/api/routes/flag_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, request
+from flask import current_app, request
 
 from assessment_store.db.models.flags.flag_update import FlagStatus
 from assessment_store.db.queries import get_metadata_for_fund_round_id
@@ -9,6 +9,7 @@ from assessment_store.db.queries.flags.queries import (
     get_flags_for_application,
 )
 from assessment_store.db.schemas.schemas import AssessmentFlagSchema
+from common.blueprints import Blueprint
 
 assessment_flag_bp = Blueprint("assessment_flag", __name__)
 

--- a/assessment_store/api/routes/progress_routes.py
+++ b/assessment_store/api/routes/progress_routes.py
@@ -1,9 +1,10 @@
 import copy
 from typing import List
 
-from flask import Blueprint, request
+from flask import request
 
 from assessment_store.db.queries.progress.queries import get_progress_for_app
+from common.blueprints import Blueprint
 from config import Config
 
 assessment_progress_bp = Blueprint("assessment_progress_bp", __name__)

--- a/assessment_store/api/routes/qa_complete_routes.py
+++ b/assessment_store/api/routes/qa_complete_routes.py
@@ -1,10 +1,9 @@
-from flask import Blueprint
-
 from assessment_store.db.queries.assessment_records.queries import get_metadata_for_application
 from assessment_store.db.queries.qa_complete.queries import (
     create_qa_complete_record,
     get_qa_complete_record_for_application,
 )
+from common.blueprints import Blueprint
 
 assessment_qa_bp = Blueprint("assessment_qa_bp", __name__)
 

--- a/assessment_store/api/routes/score_routes.py
+++ b/assessment_store/api/routes/score_routes.py
@@ -1,13 +1,14 @@
 from distutils.util import strtobool
 from typing import Dict, List
 
-from flask import Blueprint, request
+from flask import request
 
 from assessment_store.db.queries import (
     create_score_for_app_sub_crit,
     get_scores_for_app_sub_crit,
     get_scoring_system_for_round_id,
 )
+from common.blueprints import Blueprint
 
 assessment_score_bp = Blueprint("assessment_score_bp", __name__)
 

--- a/assessment_store/api/routes/tag_routes.py
+++ b/assessment_store/api/routes/tag_routes.py
@@ -1,6 +1,6 @@
 from distutils.util import strtobool
 
-from flask import Blueprint, Response, abort, current_app, request
+from flask import Response, abort, current_app, request
 
 from assessment_store.db.queries.assessment_records.queries import (
     associate_assessment_tags,
@@ -21,6 +21,7 @@ from assessment_store.db.schemas.schemas import (
     TagSchema,
     TagTypeSchema,
 )
+from common.blueprints import Blueprint
 
 assessment_tag_bp = Blueprint("assessment_tag_bp", __name__)
 

--- a/assessment_store/api/routes/user_routes.py
+++ b/assessment_store/api/routes/user_routes.py
@@ -1,6 +1,6 @@
 from distutils.util import strtobool
 
-from flask import Blueprint, abort, current_app, request
+from flask import abort, current_app, request
 from fsd_utils.config.notify_constants import NotifyConstants
 
 from assessment_store.db.queries.assessment_records.queries import (
@@ -13,6 +13,7 @@ from assessment_store.db.queries.assessment_records.queries import (
 )
 from assessment_store.db.schemas.schemas import AllocationAssociationSchema
 from assessment_store.services.data_services import send_notification_email
+from common.blueprints import Blueprint
 
 assessment_user_bp = Blueprint("assessment_user_bp", __name__)
 

--- a/common/blueprints.py
+++ b/common/blueprints.py
@@ -1,0 +1,38 @@
+# lifted from https://github.com/communitiesuk/funding-service-pre-award-frontend/blob/main/common/blueprints.py
+from flask.blueprints import Blueprint as FlaskBlueprint
+from flask.blueprints import BlueprintSetupState as FlaskBlueprintSetupState
+
+
+class BlueprintSetupState(FlaskBlueprintSetupState):
+    """Adds the ability to set a hostname on all routes when registering the blueprint."""
+
+    def __init__(self, blueprint, app, options, first_registration):
+        super().__init__(blueprint, app, options, first_registration)
+
+        host = self.options.get("host")
+        self.host = host
+
+        # This creates a 'blueprint_name.static' endpoint.
+        # The location of the static folder is shared with the app static folder,
+        # but all static resources will be served via the blueprint's hostname.
+        if app.url_map.host_matching and not self.blueprint.has_static_folder:
+            url_prefix = self.url_prefix
+            self.url_prefix = None
+            self.add_url_rule(
+                f"{app.static_url_path}/<path:filename>",
+                view_func=app.send_static_file,
+                endpoint="static",
+            )
+            self.url_prefix = url_prefix
+
+    def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
+        # Ensure that every route registered by this blueprint has the host parameter
+        options.setdefault("host", self.host)
+        super().add_url_rule(rule, endpoint, view_func, **options)
+
+
+class Blueprint(FlaskBlueprint):
+    """A Flask Blueprint class that supports passing a `host` argument when registering blueprints"""
+
+    def make_setup_state(self, app, options, first_registration=False):
+        return BlueprintSetupState(self, app, options, first_registration)

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -2,7 +2,7 @@
 
 import logging
 from distutils.util import strtobool
-from os import environ
+from os import environ, getenv
 from pathlib import Path
 
 from fsd_utils import CommonConfig, configclass
@@ -95,3 +95,6 @@ class DefaultConfig(object):
     # ---------------
     AWS_SQS_NOTIF_APP_PRIMARY_QUEUE_URL = environ.get("AWS_SQS_NOTIF_APP_PRIMARY_QUEUE_URL")
     AWS_SQS_NOTIF_APP_SECONDARY_QUEUE_URL = environ.get("AWS_SQS_NOTIF_APP_SECONDARY_QUEUE_URL")
+
+    # Frontends
+    API_HOST = getenv("API_HOST", "api.levellingup.gov.localhost:3012")

--- a/copilot/fsd-pre-award-stores/manifest.yml
+++ b/copilot/fsd-pre-award-stores/manifest.yml
@@ -54,6 +54,7 @@ variables:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-NotificationDeadLetterQueueURL
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   SENTRY_TRACES_SAMPLE_RATE: 1.0
+  API_HOST: "fsd-pre-award-stores:8080"
 
 secrets:
   FUND_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FUND_STORE_API_HOST

--- a/fund_store/api/routes.py
+++ b/fund_store/api/routes.py
@@ -2,9 +2,10 @@ import uuid
 from datetime import datetime
 from distutils.util import strtobool
 
-from flask import Blueprint, abort, current_app, jsonify, request
+from flask import abort, current_app, jsonify, request
 from fsd_utils.locale_selector.get_lang import get_lang
 
+from common.blueprints import Blueprint
 from db import db
 from fund_store.db.models import Round
 from fund_store.db.models.event import EventType


### PR DESCRIPTION
Adds host matching to the existing store APIs allowing different routes/
blueprints to serve different host headers. This sets the app up to be
able to continue to serve the store APIs as frontends are added on top.

The existing store tests should set their headers as if they're
accessing the API routes.

Note this just configures each stores separately as thats how they are
setup from combining the repositories. This will likely be streamlined
to one test client for tests as we refactor away the store + frontend
boundaries.

In order for this to work locally this depends on:
- [x] https://github.com/communitiesuk/funding-service-design-docker-runner/pull/112