### PR TITLE
Disable DB migrations for first deployment

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -63,7 +63,7 @@ jobs:
     with:
       environment: dev
       app_name: pre-award
-      run_db_migrations: false
+      run_db_migrations: true
       image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_dev_deploy_tests:
@@ -94,7 +94,7 @@ jobs:
     with:
       environment: test
       app_name: pre-award
-      run_db_migrations: true
+      run_db_migrations: false
       image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_test_deploy_tests:
@@ -126,7 +126,7 @@ jobs:
     with:
       environment: uat
       app_name: pre-award
-      run_db_migrations: true
+      run_db_migrations: false
       image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_uat_deploy_tests:
@@ -158,5 +158,5 @@ jobs:
     with:
       environment: prod
       app_name: pre-award
-      run_db_migrations: true
+      run_db_migrations: false
       image_location: ${{ needs.paketo_build.outputs.image_location }}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-179

### Change description
When we're doing the first deployment of a new app, there isn't an image available for the DB migrations task to run until _after_ the service has been deployed for the first time.

So we'll toggle these off, deploy, and then toggle them back on.

Dev is already done.

This was missed in https://github.com/communitiesuk/funding-service-pre-award-stores/pull/76